### PR TITLE
fix: logging response type & unknown classes

### DIFF
--- a/lib/src/backend/frappe/frappe.log.manager.dart
+++ b/lib/src/backend/frappe/frappe.log.manager.dart
@@ -39,7 +39,7 @@ class FrappeLogManager extends RenovationController implements LogManager {
   }
 
   @override
-  Future<RequestResponse> info(
+  Future<RequestResponse<FrappeLog>> info(
       {@required String content, String title, List<String> tags}) {
     if (content == null || content.isEmpty) {
       throw EmptyContentError();
@@ -52,7 +52,7 @@ class FrappeLogManager extends RenovationController implements LogManager {
   }
 
   @override
-  Future<RequestResponse> warning(
+  Future<RequestResponse<FrappeLog>> warning(
       {@required String content, String title, List<String> tags}) {
     if (content == null || content.isEmpty) {
       throw EmptyContentError();
@@ -65,7 +65,7 @@ class FrappeLogManager extends RenovationController implements LogManager {
   }
 
   @override
-  Future<RequestResponse> logRequest(
+  Future<RequestResponse<FrappeLog>> logRequest(
       {@required RequestResponse<dynamic> r, List<String> tags}) {
     if (r == null) {
       throw EmptyResponseError();
@@ -128,8 +128,7 @@ class FrappeLogManager extends RenovationController implements LogManager {
           FrappeLog.fromJson(logResponse.data.message),
           rawResponse: logResponse.rawResponse);
     } else {
-      return RequestResponse.fail<dynamic>(
-          handleError(null, logResponse.error));
+      return RequestResponse.fail(handleError(null, logResponse.error));
     }
   }
 }

--- a/lib/src/storage/frappe/frappe.socketiouploader.dart
+++ b/lib/src/storage/frappe/frappe.socketiouploader.dart
@@ -35,7 +35,7 @@ class FrappeSocketIOUploader implements IErrorHandler {
   /// The subject to subscribe updates about the upload
   BehaviorSubject<FrappeUploadStatus> uploadStatus =
       BehaviorSubject<FrappeUploadStatus>.seeded(
-          FrappeUploadStatus()..status = Status.ready);
+          FrappeUploadStatus()..status = UploadingStatus.ready);
 
   /// The file as a buffer being uploaded
   Uint8List file;
@@ -126,7 +126,7 @@ class FrappeSocketIOUploader implements IErrorHandler {
     if (currentSlice > 0) {
       var progress = (((currentSlice * chunkSize) / fileSize) * 100).round();
       uploadStatus.add(FrappeUploadStatus()
-        ..status = Status.uploading
+        ..status = UploadingStatus.uploading
         ..filename = args.fileName
         ..progress = progress
         ..hasProgress = true);
@@ -167,7 +167,7 @@ class FrappeSocketIOUploader implements IErrorHandler {
   /// @param event The name of the event emitted
   void _onError(ErrorEvent event) {
     uploadStatus.add(FrappeUploadStatus()
-      ..status = Status.error
+      ..status = UploadingStatus.error
       ..error = event);
 
     _getCore().config.logger.w(
@@ -209,7 +209,8 @@ class FrappeSocketIOUploader implements IErrorHandler {
     }
 
     uploadStatus.add(FrappeUploadStatus()
-      ..status = r.isSuccess ? Status.completed : Status.detail_error
+      ..status = r.isSuccess ? UploadingStatus.completed : UploadingStatus
+          .detail_error
       ..progress = 100
       ..filename = args.fileName
       ..r = uploadResponse);

--- a/lib/src/storage/frappe/interfaces.g.dart
+++ b/lib/src/storage/frappe/interfaces.g.dart
@@ -147,7 +147,7 @@ Map<String, dynamic> _$FrappeFileToJson(FrappeFile instance) {
 
 FrappeUploadStatus _$FrappeUploadStatusFromJson(Map<String, dynamic> json) {
   return FrappeUploadStatus()
-    ..status = _$enumDecodeNullable(_$StatusEnumMap, json['status'])
+    ..status = _$enumDecodeNullable(_$UploadingStatusEnumMap, json['status'])
     ..hasProgress = json['hasProgress'] as bool
     ..progress = json['progress'] as num
     ..error = _$enumDecodeNullable(_$ErrorEventEnumMap, json['error'])
@@ -163,7 +163,7 @@ Map<String, dynamic> _$FrappeUploadStatusToJson(FrappeUploadStatus instance) {
     }
   }
 
-  writeNotNull('status', _$StatusEnumMap[instance.status]);
+  writeNotNull('status', _$UploadingStatusEnumMap[instance.status]);
   writeNotNull('hasProgress', instance.hasProgress);
   writeNotNull('progress', instance.progress);
   writeNotNull('error', _$ErrorEventEnumMap[instance.error]);
@@ -203,12 +203,12 @@ T _$enumDecodeNullable<T>(
   return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
 }
 
-const _$StatusEnumMap = {
-  Status.ready: 'ready',
-  Status.uploading: 'uploading',
-  Status.completed: 'completed',
-  Status.error: 'error',
-  Status.detail_error: 'detail_error',
+const _$UploadingStatusEnumMap = {
+  UploadingStatus.ready: 'ready',
+  UploadingStatus.uploading: 'uploading',
+  UploadingStatus.completed: 'completed',
+  UploadingStatus.error: 'error',
+  UploadingStatus.detail_error: 'detail_error',
 };
 
 const _$ErrorEventEnumMap = {

--- a/lib/src/storage/interfaces.dart
+++ b/lib/src/storage/interfaces.dart
@@ -1,9 +1,8 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 import '../../core.dart';
 import '../core/jsonable.dart';
-
-import 'package:meta/meta.dart';
 
 abstract class UploadFileParams extends JSONAble {
   UploadFileParams(
@@ -29,7 +28,7 @@ abstract class UploadFileResponse extends JSONAble {
   String fileUrl;
 }
 
-enum Status { ready, uploading, completed, error, detail_error }
+enum UploadingStatus { ready, uploading, completed, error, detail_error }
 
 enum ErrorEvent {
   no_socketio,
@@ -40,7 +39,7 @@ enum ErrorEvent {
 }
 
 abstract class UploadFileStatus extends JSONAble{
-  Status status;
+  UploadingStatus status;
   bool hasProgress;
   num progress;
   ErrorEvent error;

--- a/test/tests/backend/frappe/frappe_log_manager_test.dart
+++ b/test/tests/backend/frappe/frappe_log_manager_test.dart
@@ -22,7 +22,7 @@ void main() {
       test('logging basic info', () async {
         var response = await log.info(content: 'Test Info 1');
 
-        FrappeLog logged = response.data;
+        var logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Info');
@@ -32,7 +32,7 @@ void main() {
         var response = await log.info(
             content: 'Test Info 2', tags: ['TAG1', 'TAG2'], title: 'TitleA');
 
-        FrappeLog logged = response.data;
+        var logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Info');
@@ -51,7 +51,7 @@ void main() {
       test('logging basic error', () async {
         var response = await log.error(content: 'Test error 1');
 
-        FrappeLog logged = response.data;
+        var logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Error');
@@ -61,7 +61,7 @@ void main() {
         var response = await log.error(
             content: 'Test error 2', tags: ['TAG1', 'TAG2'], title: 'TitleA');
 
-        FrappeLog logged = response.data;
+        var logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Error');
@@ -80,7 +80,7 @@ void main() {
       test('logging basic warning', () async {
         var response = await log.warning(content: 'Test warning 1');
 
-        FrappeLog logged = response.data;
+        var logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Warning');
@@ -90,7 +90,7 @@ void main() {
         var response = await log.warning(
             content: 'Test warning 2', tags: ['TAG1', 'TAG2'], title: 'TitleA');
 
-        FrappeLog logged = response.data;
+        var logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Warning');
@@ -115,7 +115,7 @@ void main() {
       test('Successful Request Log', () async {
         var r = await log.logRequest(r: response);
         expect(r.isSuccess, true);
-        FrappeLog logged = r.data;
+        var logged = r.data;
         expect(logged?.type, 'Request');
         expect(logged?.request != null, true);
         expect(logged?.response != null, true);

--- a/test/tests/backend/frappe/frappe_log_manager_test.dart
+++ b/test/tests/backend/frappe/frappe_log_manager_test.dart
@@ -43,7 +43,7 @@ void main() {
       });
       test('failed logging basic info on empty content', () async {
         expect(() => log.info(content: ''),
-            throwsA(TypeMatcher<ContentError>()));
+            throwsA(TypeMatcher<EmptyContentError>()));
       });
     });
 
@@ -72,7 +72,7 @@ void main() {
       });
       test('failed logging basic error on empty content', () async {
         expect(() => log.error(content: ''),
-            throwsA(TypeMatcher<ContentError>()));
+            throwsA(TypeMatcher<EmptyContentError>()));
       });
     });
 
@@ -101,7 +101,7 @@ void main() {
       });
       test('failed logging basic warning on empty content', () async {
         expect(() => log.warning(content: ''),
-            throwsA(TypeMatcher<ContentError>()));
+            throwsA(TypeMatcher<EmptyContentError>()));
       });
     });
 
@@ -122,7 +122,7 @@ void main() {
       });
       test('Request Log on empty response', () async {
         expect(() => log.logRequest(r: response = null),
-            throwsA(TypeMatcher<ResponseError>()));
+            throwsA(TypeMatcher<EmptyResponseError>()));
       });
     });
   });

--- a/test/tests/storage/frappe/frappe_storage_controller_test.dart
+++ b/test/tests/storage/frappe/frappe_storage_controller_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
 import 'package:renovation_core/core.dart';
 import 'package:renovation_core/storage.dart';
-import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../../../test_manager.dart';
@@ -143,9 +143,10 @@ void main() {
       // A 512 KB will be divided into 21 chunks
       // So we generate a list of uploading status (21 of them) and concluded by a .completedStatus
 
-      final statusProgress = List<Status>.generate(21, (i) => Status.uploading);
+      final statusProgress =
+          List<UploadingStatus>.generate(21, (i) => UploadingStatus.uploading);
 
-      statusProgress.add(Status.completed);
+      statusProgress.add(UploadingStatus.completed);
 
       final file = File(path.absolute('test/assets/socketio_image.jpg'));
       await expectLater(


### PR DESCRIPTION
- Resolved issue in the frappe_log_manager_test.dart containing unknown classes.
- Added explicit response type to log managers with FrappeLog.
- Refactored Status to UploadingStatus in Frappe Storage Controller #2 