### PR TITLE
fix: Fixes/Modifications+Test Manager Modification

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -35,3 +35,4 @@ analyzer:
     sdk_version_async_exported_from_core: ignore
   exclude:
     - "lib/**/*.g.dart"
+    - "test/**/*.g.dart"

--- a/lib/src/auth/frappe/interfaces.dart
+++ b/lib/src/auth/frappe/interfaces.dart
@@ -1,7 +1,6 @@
 import 'dart:core';
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:renovation_core/core.dart';
 
 import '../../core/jsonable.dart';
 import '../../model/frappe/document.dart';
@@ -120,9 +119,29 @@ class User extends FrappeDocument {
   @JsonKey(name: 'user_image')
   String userImage;
 
+  @JsonKey(name: 'block_modules')
+  List<BlockModule> blockModules;
+
   @override
   Map<String, dynamic> toJson() => _$UserToJson(this);
 
   @override
   T fromJson<T>(Map<String, dynamic> json) => User.fromJson(json) as T;
+}
+
+@JsonSerializable()
+class BlockModule extends FrappeDocument {
+  BlockModule() : super('Block Module');
+
+  factory BlockModule.fromJson(Map<String, dynamic> json) =>
+      _$BlockModuleFromJson(json);
+
+  @JsonKey(name: 'module')
+  String module;
+
+  @override
+  T fromJson<T>(Map<String, dynamic> json) => BlockModule.fromJson(json) as T;
+
+  @override
+  Map<String, dynamic> toJson() => _$BlockModuleToJson(this);
 }

--- a/lib/src/auth/frappe/interfaces.g.dart
+++ b/lib/src/auth/frappe/interfaces.g.dart
@@ -130,7 +130,11 @@ User _$UserFromJson(Map<String, dynamic> json) {
     ..lastLogin = json['last_login'] == null
         ? null
         : DateTime.parse(json['last_login'] as String)
-    ..userImage = json['user_image'] as String;
+    ..userImage = json['user_image'] as String
+    ..blockModules = (json['block_modules'] as List)
+        ?.map((e) =>
+            e == null ? null : BlockModule.fromJson(e as Map<String, dynamic>))
+        ?.toList();
 }
 
 Map<String, dynamic> _$UserToJson(User instance) {
@@ -174,5 +178,63 @@ Map<String, dynamic> _$UserToJson(User instance) {
   writeNotNull('mobile_no', instance.mobileNo);
   writeNotNull('last_login', instance.lastLogin?.toIso8601String());
   writeNotNull('user_image', instance.userImage);
+  writeNotNull('block_modules',
+      instance.blockModules?.map((e) => e?.toJson())?.toList());
+  return val;
+}
+
+BlockModule _$BlockModuleFromJson(Map<String, dynamic> json) {
+  return BlockModule()
+    ..doctype = json['doctype'] as String
+    ..name = json['name'] as String
+    ..owner = json['owner'] as String
+    ..docStatus =
+        FrappeDocFieldConverter.intToFrappeDocStatus(json['docstatus'] as int)
+    ..isLocal = FrappeDocFieldConverter.checkToBool(json['__islocal'] as int)
+    ..unsaved = FrappeDocFieldConverter.checkToBool(json['__unsaved'] as int)
+    ..amendedFrom = json['amended_from'] as String
+    ..idx = FrappeDocFieldConverter.idxFromString(json['idx'])
+    ..parent = json['parent'] as String
+    ..parentType = json['parenttype'] as String
+    ..creation = json['creation'] == null
+        ? null
+        : DateTime.parse(json['creation'] as String)
+    ..parentField = json['parentfield'] as String
+    ..modified = json['modified'] == null
+        ? null
+        : DateTime.parse(json['modified'] as String)
+    ..modifiedBy = json['modified_by'] as String
+    ..module = json['module'] as String;
+}
+
+Map<String, dynamic> _$BlockModuleToJson(BlockModule instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('doctype', instance.doctype);
+  writeNotNull('name', instance.name);
+  writeNotNull('owner', instance.owner);
+  writeNotNull('docstatus',
+      FrappeDocFieldConverter.frappeDocStatusToInt(instance.docStatus));
+  writeNotNull(
+      '__islocal', FrappeDocFieldConverter.boolToCheck(instance.isLocal));
+  writeNotNull(
+      '__unsaved', FrappeDocFieldConverter.boolToCheck(instance.unsaved));
+  writeNotNull('amended_from', instance.amendedFrom);
+  writeNotNull('idx', instance.idx);
+  writeNotNull('parent', instance.parent);
+  writeNotNull('parenttype', instance.parentType);
+  writeNotNull(
+      'creation', FrappeDocFieldConverter.toFrappeDateTime(instance.creation));
+  writeNotNull('parentfield', instance.parentField);
+  writeNotNull(
+      'modified', FrappeDocFieldConverter.toFrappeDateTime(instance.modified));
+  writeNotNull('modified_by', instance.modifiedBy);
+  writeNotNull('module', instance.module);
   return val;
 }

--- a/lib/src/backend/frappe/frappe.dart
+++ b/lib/src/backend/frappe/frappe.dart
@@ -133,7 +133,7 @@ class Frappe extends RenovationController implements FCMController {
   ///
   /// If the token is already registered, the backend will silently returning a success.
   @override
-  Future<RequestResponse<FrappeResponse>> registerFCMToken(String token) async {
+  Future<RequestResponse<String>> registerFCMToken(String token) async {
     final response = await Request.initiateRequest(
         url: config.hostUrl,
         method: HttpMethod.POST,
@@ -144,11 +144,11 @@ class Frappe extends RenovationController implements FCMController {
         });
 
     if (response.isSuccess == true) {
-      return RequestResponse.success(response.data,
+      return RequestResponse.success(response.data.message,
           rawResponse: response.rawResponse);
     }
     response.isSuccess = false;
-    return RequestResponse.fail<FrappeResponse>(handleError(
+    return RequestResponse.fail(handleError(
         'fcm_register_client',
         response.error ??
             ErrorDetail(
@@ -176,7 +176,7 @@ class Frappe extends RenovationController implements FCMController {
           rawResponse: response.rawResponse);
     }
     response.isSuccess = false;
-    return RequestResponse.fail<FrappeResponse>(handleError(
+    return RequestResponse.fail(handleError(
         'fcm_unregister_client',
         response.error ??
             ErrorDetail(

--- a/lib/src/core/errors.dart
+++ b/lib/src/core/errors.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:renovation_core/core.dart';
 
 import 'request.dart' show RenovationError;
 

--- a/lib/src/core/renovation.dart
+++ b/lib/src/core/renovation.dart
@@ -149,11 +149,11 @@ class Renovation {
 
   /// Clears the cache of the renovation controllers. Involved controllers:
   ///
-  /// - `FrappeModelController`
-  /// - `FrappeMetaController`
-  /// - `FrappeAuthController`
-  /// - `ScriptManager`
-  /// - `FrappeUIController`
+  /// - [FrappeModelController]
+  /// - [FrappeMetaController]
+  /// - [FrappeAuthController]
+  /// - [FrappePermissionController]
+  /// - [Frappe]
   void clearCache() {
     for (final renovationController in <RenovationController>[
       model,

--- a/lib/src/meta/frappe/doctype.dart
+++ b/lib/src/meta/frappe/doctype.dart
@@ -1,7 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
-import 'package:renovation_core/model.dart';
 
 import '../../model/frappe/document.dart';
+import '../../model/frappe/utils.dart';
 import '../../perm/frappe/interfaces.dart';
 import 'docfield.dart';
 

--- a/lib/src/meta/frappe/frappe.meta.controller.dart
+++ b/lib/src/meta/frappe/frappe.meta.controller.dart
@@ -124,15 +124,10 @@ class FrappeMetaController extends MetaController {
           metas[dmeta.name] = dmeta;
           // append __messages for translations
 
-          config.coreInstance.translate.extendDictionary(dict: dmeta.messages);
-          //FIXME: Core-Dart doesn't support renovation scripts yet
-          // Renovation Scripts
-          // if (dmeta['renovation_scripts'] != null) {
-          // for (RenovationScripts s in dmeta['renovation_scripts']) {
-          // config.coreInstance.scriptManager
-          // .addScript(doctype, s.code, s.name);
-          // }
-          // }
+          config.coreInstance.translate.extendDictionary(
+              dict: dmeta.messages != null
+                  ? dmeta.messages.cast<String, String>()
+                  : null);
         }
       }
       docTypeCache.addAll(metas);
@@ -155,7 +150,7 @@ class FrappeMetaController extends MetaController {
   ///
   /// If the field exists withing the [doctype], the title case equivalent is returned.
   ///
-  /// For example, item_group of Item doctype will return 'Item Group'.
+  /// For example, full_name of User doctype will return 'Full Name'.
   ///
   /// If the doctype or the field doesn't exist, [fieldName] is returned.
   @override

--- a/lib/src/meta/meta.controller.dart
+++ b/lib/src/meta/meta.controller.dart
@@ -31,16 +31,4 @@ abstract class MetaController extends RenovationController {
   ///
   /// Can specify the return within [RequestResponse] in the extending class.
   Future<RequestResponse<dynamic>> getReportMeta({@required String report});
-
-//FIXME: Since Dart doesn't support the Scripts yet
-//  Future<RequestResponse<bool>> loadDocTypeScripts(
-//      dynamic doctype) async {
-//    dynamic dt;
-//    if (doctype.runtimeType == String) {
-//      dt = doctype;
-//    } else {
-//      dt = doctype.doctype;
-//    }
-//    return config.coreInstance.scriptManager.loadScripts(dt);
-//  }
 }

--- a/lib/src/model/frappe/filters.dart
+++ b/lib/src/model/frappe/filters.dart
@@ -19,7 +19,7 @@ class DBFilter {
   /// [
   /// ['name', 'LIKE', 'test']
   /// ]
-  /// ```w
+  /// ```
   ///
   /// 3. Type3:
   /// ```

--- a/lib/src/model/frappe/interfaces.dart
+++ b/lib/src/model/frappe/interfaces.dart
@@ -362,3 +362,27 @@ class FrappeLogTag extends FrappeDocument {
   @override
   Map<String, dynamic> toJson() => _$FrappeLogTagToJson(this);
 }
+
+@JsonSerializable()
+class TagLink extends FrappeDocument {
+  TagLink() : super('Tag Link');
+
+  factory TagLink.fromJson(Map<String, dynamic> json) =>
+      _$TagLinkFromJson(json);
+
+  @JsonKey(name: 'document_type')
+  String documentType;
+
+  @JsonKey(name: 'document_name')
+  String documentName;
+
+  String tag;
+
+  String title;
+
+  @override
+  T fromJson<T>(Map<String, dynamic> json) => TagLink.fromJson(json) as T;
+
+  @override
+  Map<String, dynamic> toJson() => _$TagLinkToJson(this);
+}

--- a/lib/src/model/frappe/interfaces.g.dart
+++ b/lib/src/model/frappe/interfaces.g.dart
@@ -534,3 +534,65 @@ Map<String, dynamic> _$FrappeLogTagToJson(FrappeLogTag instance) {
   writeNotNull('tag', instance.tag);
   return val;
 }
+
+TagLink _$TagLinkFromJson(Map<String, dynamic> json) {
+  return TagLink()
+    ..doctype = json['doctype'] as String
+    ..name = json['name'] as String
+    ..owner = json['owner'] as String
+    ..docStatus =
+        FrappeDocFieldConverter.intToFrappeDocStatus(json['docstatus'] as int)
+    ..isLocal = FrappeDocFieldConverter.checkToBool(json['__islocal'] as int)
+    ..unsaved = FrappeDocFieldConverter.checkToBool(json['__unsaved'] as int)
+    ..amendedFrom = json['amended_from'] as String
+    ..idx = FrappeDocFieldConverter.idxFromString(json['idx'])
+    ..parent = json['parent'] as String
+    ..parentType = json['parenttype'] as String
+    ..creation = json['creation'] == null
+        ? null
+        : DateTime.parse(json['creation'] as String)
+    ..parentField = json['parentfield'] as String
+    ..modified = json['modified'] == null
+        ? null
+        : DateTime.parse(json['modified'] as String)
+    ..modifiedBy = json['modified_by'] as String
+    ..documentType = json['document_type'] as String
+    ..documentName = json['document_name'] as String
+    ..tag = json['tag'] as String
+    ..title = json['title'] as String;
+}
+
+Map<String, dynamic> _$TagLinkToJson(TagLink instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('doctype', instance.doctype);
+  writeNotNull('name', instance.name);
+  writeNotNull('owner', instance.owner);
+  writeNotNull('docstatus',
+      FrappeDocFieldConverter.frappeDocStatusToInt(instance.docStatus));
+  writeNotNull(
+      '__islocal', FrappeDocFieldConverter.boolToCheck(instance.isLocal));
+  writeNotNull(
+      '__unsaved', FrappeDocFieldConverter.boolToCheck(instance.unsaved));
+  writeNotNull('amended_from', instance.amendedFrom);
+  writeNotNull('idx', instance.idx);
+  writeNotNull('parent', instance.parent);
+  writeNotNull('parenttype', instance.parentType);
+  writeNotNull(
+      'creation', FrappeDocFieldConverter.toFrappeDateTime(instance.creation));
+  writeNotNull('parentfield', instance.parentField);
+  writeNotNull(
+      'modified', FrappeDocFieldConverter.toFrappeDateTime(instance.modified));
+  writeNotNull('modified_by', instance.modifiedBy);
+  writeNotNull('document_type', instance.documentType);
+  writeNotNull('document_name', instance.documentName);
+  writeNotNull('tag', instance.tag);
+  writeNotNull('title', instance.title);
+  return val;
+}

--- a/lib/src/model/model.controller.dart
+++ b/lib/src/model/model.controller.dart
@@ -32,7 +32,7 @@ abstract class ModelController<K extends RenovationDocument>
   /// Returns a new instance of [T] document with a new name based on [getNewName].
   T newDoc<T extends K>(T doc);
 
-  /// Returns a new name for a doctype. For instance, `New Sales Invoice 1`.
+  /// Returns a new name for a doctype. For instance, `New Renovation Review 1`.
   @protected
   String getNewName(String doctype);
 

--- a/lib/src/storage/frappe/interfaces.dart
+++ b/lib/src/storage/frappe/interfaces.dart
@@ -14,7 +14,7 @@ class FrappeUploadFileParams extends UploadFileParams with FrappeAPI {
       {@required dynamic file,
       @required String fileName,
       this.isPrivate,
-      this.folder = 'Home',
+      @deprecated this.folder = 'Home',
       @deprecated this.doctype,
       @deprecated this.docname,
       @deprecated this.docField})

--- a/test/test_manager.dart
+++ b/test/test_manager.dart
@@ -1,34 +1,52 @@
+import 'dart:io';
+
 import 'package:renovation_core/core.dart';
 
 class TestManager {
   /// Holds the test instance of Renovation
   static Renovation renovation;
+  static final Map<String, String> _envVariables = Platform.environment;
 
-  static Future<Renovation> getTestInstance({int hostIndex = 0}) async {
+  static Future<Renovation> getTestInstance() async {
     if (renovation == null) {
       renovation = Renovation();
 
-//      final Map<String, String> credentials = getTestUserCredentials();
+//      print(_envVariables);
 
-      print('CORE INIT: ${hostUrls[hostIndex]}');
-      await renovation.init(hostUrls[hostIndex]);
+      await renovation.init(_envVariables[EnvVariables.HostURL],
+          disableLog: true);
     }
     return renovation;
   }
 
-  /// A getter for the used credentials across the testing environment
-  static Map<String, String> getTestUserCredentials() =>
-      Map<String, String>.of(<String, String>{
-        'email': '<admin_user>',
-        'password': '<password>',
-        'fullName': '<admin_user>'
-      });
+  static String getVariable(String variableName) => _envVariables[variableName];
 
-  ///Holds the host URLs of the backend
-  ///
-  /// Useful if another app on another site needs to be tested
-  static List<String> hostUrls = <String>[
-    '<host_url>',
-    'http://localhost:8000'
-  ];
+  static final String primaryUser = _envVariables[EnvVariables.PrimaryUser];
+  static final String primaryUserPwd =
+      _envVariables[EnvVariables.PrimaryUserPwd];
+  static final String secondaryUser = _envVariables[EnvVariables.SecondaryUser];
+  static final String secondaryUserPwd =
+      _envVariables[EnvVariables.SecondaryUserPwd];
+  static final String mobileNumber = _envVariables[EnvVariables.MobileNumber];
+}
+
+class EnvVariables {
+  // Prefix variables to avoid any conflict with existing variables
+  static const String _envPrefix = 'CORE_DART_';
+
+  // Host URL
+  static const String HostURL = '${_envPrefix}HOST_URL';
+
+  // Users
+  static const String PrimaryUser = '${_envPrefix}PRIMARY_USER';
+  static const String PrimaryUserPwd = '${_envPrefix}PRIMARY_USER_PWD';
+  static const String PrimaryUserName = '${_envPrefix}PRIMARY_USER_NAME';
+  static const String PrimaryUserEmail = '${_envPrefix}PRIMARY_USER_EMAIL';
+  static const String SecondaryUser = '${_envPrefix}SECONDARY_USER';
+  static const String SecondaryUserPwd = '${_envPrefix}SECONDARY_USER_PWD';
+  static const String MobileNumber = '${_envPrefix}MOBILE_NUMBER';
+  static const String PinNumber = '${_envPrefix}PIN_NUMBER';
+
+  // Storage
+  static const String ExistingFolder = '${_envPrefix}EXISTING_FOLDER';
 }

--- a/test/test_manager.dart
+++ b/test/test_manager.dart
@@ -11,8 +11,6 @@ class TestManager {
     if (renovation == null) {
       renovation = Renovation();
 
-//      print(_envVariables);
-
       await renovation.init(_envVariables[EnvVariables.HostURL],
           disableLog: true);
     }

--- a/test/test_models/models.dart
+++ b/test/test_models/models.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:renovation_core/meta.dart';
 import 'package:renovation_core/model.dart';
 
 part 'models.g.dart';
@@ -21,75 +22,53 @@ class RenovationUserAgreement extends FrappeDocument {
 }
 
 @JsonSerializable()
-class ItemGroup extends FrappeDocument {
-  ItemGroup() : super('Item Group');
+class RenovationReview extends FrappeDocument {
+  RenovationReview() : super('Renovation Review');
 
-  @JsonKey(name: 'parent_item_group_doc')
-  ParentItemGroup parentItemGroupDoc;
+  factory RenovationReview.fromJson(Map<String, dynamic> json) =>
+      _$RenovationReviewFromJson(json);
 
-  factory ItemGroup.fromJson(Map<String, dynamic> json) =>
-      _$ItemGroupFromJson(json);
+  @JsonKey(name: 'reviewed_by_doctype')
+  String reviewedByDoctype;
+  @JsonKey(name: 'reviewed_by')
+  String reviewedBy;
 
-  @override
-  T fromJson<T>(Map<String, dynamic> json) => ItemGroup.fromJson(json) as T;
+  @JsonKey(name: 'reviewed_by_doctype_doc')
+  DocType reviewedByDoctypeDoc;
 
-  @override
-  Map<String, dynamic> toJson() => _$ItemGroupToJson(this);
-}
+  @JsonKey(name: 'reviewed_doctype')
+  String reviewedDoctype;
+  @JsonKey(name: 'reviewed_entity')
+  String reviewedEntity;
 
-@JsonSerializable()
-class ParentItemGroup extends FrappeDocument {
-  ParentItemGroup() : super('Parent Item Group');
-
-  factory ParentItemGroup.fromJson(Map<String, dynamic> json) =>
-      _$ParentItemGroupFromJson(json);
+  List<RenovationReviewItem> reviews;
 
   @override
   T fromJson<T>(Map<String, dynamic> json) =>
-      ParentItemGroup.fromJson(json) as T;
+      RenovationReview.fromJson(json) as T;
 
   @override
-  Map<String, dynamic> toJson() => _$ParentItemGroupToJson(this);
+  Map<String, dynamic> toJson() => _$RenovationReviewToJson(this);
 }
 
 @JsonSerializable()
-class ItemAttribute extends FrappeDocument {
-  ItemAttribute() : super('Item Attribute');
+class RenovationReviewItem extends FrappeDocument {
+  RenovationReviewItem() : super('Renovation Review Item');
 
-  @JsonKey(name: 'item_attribute_values')
-  List<ItemAttributeValue> itemAttributeValues;
+  factory RenovationReviewItem.fromJson(Map<String, dynamic> json) =>
+      _$RenovationReviewItemFromJson(json);
 
-  @JsonKey(name: 'attribute_name')
-  String attributeName;
-
-  factory ItemAttribute.fromJson(Map<String, dynamic> json) =>
-      _$ItemAttributeFromJson(json);
-
-  @override
-  T fromJson<T>(Map<String, dynamic> json) => ItemAttribute.fromJson(json) as T;
-
-  @override
-  Map<String, dynamic> toJson() => _$ItemAttributeToJson(this);
-}
-
-@JsonSerializable()
-class ItemAttributeValue extends FrappeDocument {
-  ItemAttributeValue() : super('Item Attribute Value');
-
-  @JsonKey(name: 'attribute_value')
-  String attributeValue;
-
-  String abbr;
-
-  factory ItemAttributeValue.fromJson(Map<String, dynamic> json) =>
-      _$ItemAttributeValueFromJson(json);
+  String title;
+  String question;
+  String quantitative;
+  String answer;
 
   @override
   T fromJson<T>(Map<String, dynamic> json) =>
-      ItemAttributeValue.fromJson(json) as T;
+      RenovationReviewItem.fromJson(json) as T;
 
   @override
-  Map<String, dynamic> toJson() => _$ItemAttributeValueToJson(this);
+  Map<String, dynamic> toJson() => _$RenovationReviewItemToJson(this);
 }
 
 @JsonSerializable()

--- a/test/test_models/models.g.dart
+++ b/test/test_models/models.g.dart
@@ -64,8 +64,8 @@ Map<String, dynamic> _$RenovationUserAgreementToJson(
   return val;
 }
 
-ItemGroup _$ItemGroupFromJson(Map<String, dynamic> json) {
-  return ItemGroup()
+RenovationReview _$RenovationReviewFromJson(Map<String, dynamic> json) {
+  return RenovationReview()
     ..doctype = json['doctype'] as String
     ..name = json['name'] as String
     ..owner = json['owner'] as String
@@ -85,128 +85,22 @@ ItemGroup _$ItemGroupFromJson(Map<String, dynamic> json) {
         ? null
         : DateTime.parse(json['modified'] as String)
     ..modifiedBy = json['modified_by'] as String
-    ..parentItemGroupDoc = json['parent_item_group_doc'] == null
+    ..reviewedByDoctype = json['reviewed_by_doctype'] as String
+    ..reviewedBy = json['reviewed_by'] as String
+    ..reviewedByDoctypeDoc = json['reviewed_by_doctype_doc'] == null
         ? null
-        : ParentItemGroup.fromJson(
-            json['parent_item_group_doc'] as Map<String, dynamic>);
-}
-
-Map<String, dynamic> _$ItemGroupToJson(ItemGroup instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('doctype', instance.doctype);
-  writeNotNull('name', instance.name);
-  writeNotNull('owner', instance.owner);
-  writeNotNull('docstatus',
-      FrappeDocFieldConverter.frappeDocStatusToInt(instance.docStatus));
-  writeNotNull(
-      '__islocal', FrappeDocFieldConverter.boolToCheck(instance.isLocal));
-  writeNotNull(
-      '__unsaved', FrappeDocFieldConverter.boolToCheck(instance.unsaved));
-  writeNotNull('amended_from', instance.amendedFrom);
-  writeNotNull('idx', instance.idx);
-  writeNotNull('parent', instance.parent);
-  writeNotNull('parenttype', instance.parentType);
-  writeNotNull(
-      'creation', FrappeDocFieldConverter.toFrappeDateTime(instance.creation));
-  writeNotNull('parentfield', instance.parentField);
-  writeNotNull(
-      'modified', FrappeDocFieldConverter.toFrappeDateTime(instance.modified));
-  writeNotNull('modified_by', instance.modifiedBy);
-  writeNotNull('parent_item_group_doc', instance.parentItemGroupDoc?.toJson());
-  return val;
-}
-
-ParentItemGroup _$ParentItemGroupFromJson(Map<String, dynamic> json) {
-  return ParentItemGroup()
-    ..doctype = json['doctype'] as String
-    ..name = json['name'] as String
-    ..owner = json['owner'] as String
-    ..docStatus =
-        FrappeDocFieldConverter.intToFrappeDocStatus(json['docstatus'] as int)
-    ..isLocal = FrappeDocFieldConverter.checkToBool(json['__islocal'] as int)
-    ..unsaved = FrappeDocFieldConverter.checkToBool(json['__unsaved'] as int)
-    ..amendedFrom = json['amended_from'] as String
-    ..idx = FrappeDocFieldConverter.idxFromString(json['idx'])
-    ..parent = json['parent'] as String
-    ..parentType = json['parenttype'] as String
-    ..creation = json['creation'] == null
-        ? null
-        : DateTime.parse(json['creation'] as String)
-    ..parentField = json['parentfield'] as String
-    ..modified = json['modified'] == null
-        ? null
-        : DateTime.parse(json['modified'] as String)
-    ..modifiedBy = json['modified_by'] as String;
-}
-
-Map<String, dynamic> _$ParentItemGroupToJson(ParentItemGroup instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('doctype', instance.doctype);
-  writeNotNull('name', instance.name);
-  writeNotNull('owner', instance.owner);
-  writeNotNull('docstatus',
-      FrappeDocFieldConverter.frappeDocStatusToInt(instance.docStatus));
-  writeNotNull(
-      '__islocal', FrappeDocFieldConverter.boolToCheck(instance.isLocal));
-  writeNotNull(
-      '__unsaved', FrappeDocFieldConverter.boolToCheck(instance.unsaved));
-  writeNotNull('amended_from', instance.amendedFrom);
-  writeNotNull('idx', instance.idx);
-  writeNotNull('parent', instance.parent);
-  writeNotNull('parenttype', instance.parentType);
-  writeNotNull(
-      'creation', FrappeDocFieldConverter.toFrappeDateTime(instance.creation));
-  writeNotNull('parentfield', instance.parentField);
-  writeNotNull(
-      'modified', FrappeDocFieldConverter.toFrappeDateTime(instance.modified));
-  writeNotNull('modified_by', instance.modifiedBy);
-  return val;
-}
-
-ItemAttribute _$ItemAttributeFromJson(Map<String, dynamic> json) {
-  return ItemAttribute()
-    ..doctype = json['doctype'] as String
-    ..name = json['name'] as String
-    ..owner = json['owner'] as String
-    ..docStatus =
-        FrappeDocFieldConverter.intToFrappeDocStatus(json['docstatus'] as int)
-    ..isLocal = FrappeDocFieldConverter.checkToBool(json['__islocal'] as int)
-    ..unsaved = FrappeDocFieldConverter.checkToBool(json['__unsaved'] as int)
-    ..amendedFrom = json['amended_from'] as String
-    ..idx = FrappeDocFieldConverter.idxFromString(json['idx'])
-    ..parent = json['parent'] as String
-    ..parentType = json['parenttype'] as String
-    ..creation = json['creation'] == null
-        ? null
-        : DateTime.parse(json['creation'] as String)
-    ..parentField = json['parentfield'] as String
-    ..modified = json['modified'] == null
-        ? null
-        : DateTime.parse(json['modified'] as String)
-    ..modifiedBy = json['modified_by'] as String
-    ..itemAttributeValues = (json['item_attribute_values'] as List)
+        : DocType.fromJson(
+            json['reviewed_by_doctype_doc'] as Map<String, dynamic>)
+    ..reviewedDoctype = json['reviewed_doctype'] as String
+    ..reviewedEntity = json['reviewed_entity'] as String
+    ..reviews = (json['reviews'] as List)
         ?.map((e) => e == null
             ? null
-            : ItemAttributeValue.fromJson(e as Map<String, dynamic>))
-        ?.toList()
-    ..attributeName = json['attribute_name'] as String;
+            : RenovationReviewItem.fromJson(e as Map<String, dynamic>))
+        ?.toList();
 }
 
-Map<String, dynamic> _$ItemAttributeToJson(ItemAttribute instance) {
+Map<String, dynamic> _$RenovationReviewToJson(RenovationReview instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -234,14 +128,18 @@ Map<String, dynamic> _$ItemAttributeToJson(ItemAttribute instance) {
   writeNotNull(
       'modified', FrappeDocFieldConverter.toFrappeDateTime(instance.modified));
   writeNotNull('modified_by', instance.modifiedBy);
-  writeNotNull('item_attribute_values',
-      instance.itemAttributeValues?.map((e) => e?.toJson())?.toList());
-  writeNotNull('attribute_name', instance.attributeName);
+  writeNotNull('reviewed_by_doctype', instance.reviewedByDoctype);
+  writeNotNull('reviewed_by', instance.reviewedBy);
+  writeNotNull(
+      'reviewed_by_doctype_doc', instance.reviewedByDoctypeDoc?.toJson());
+  writeNotNull('reviewed_doctype', instance.reviewedDoctype);
+  writeNotNull('reviewed_entity', instance.reviewedEntity);
+  writeNotNull('reviews', instance.reviews?.map((e) => e?.toJson())?.toList());
   return val;
 }
 
-ItemAttributeValue _$ItemAttributeValueFromJson(Map<String, dynamic> json) {
-  return ItemAttributeValue()
+RenovationReviewItem _$RenovationReviewItemFromJson(Map<String, dynamic> json) {
+  return RenovationReviewItem()
     ..doctype = json['doctype'] as String
     ..name = json['name'] as String
     ..owner = json['owner'] as String
@@ -261,11 +159,14 @@ ItemAttributeValue _$ItemAttributeValueFromJson(Map<String, dynamic> json) {
         ? null
         : DateTime.parse(json['modified'] as String)
     ..modifiedBy = json['modified_by'] as String
-    ..attributeValue = json['attribute_value'] as String
-    ..abbr = json['abbr'] as String;
+    ..title = json['title'] as String
+    ..question = json['question'] as String
+    ..quantitative = json['quantitative'] as String
+    ..answer = json['answer'] as String;
 }
 
-Map<String, dynamic> _$ItemAttributeValueToJson(ItemAttributeValue instance) {
+Map<String, dynamic> _$RenovationReviewItemToJson(
+    RenovationReviewItem instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -293,8 +194,10 @@ Map<String, dynamic> _$ItemAttributeValueToJson(ItemAttributeValue instance) {
   writeNotNull(
       'modified', FrappeDocFieldConverter.toFrappeDateTime(instance.modified));
   writeNotNull('modified_by', instance.modifiedBy);
-  writeNotNull('attribute_value', instance.attributeValue);
-  writeNotNull('abbr', instance.abbr);
+  writeNotNull('title', instance.title);
+  writeNotNull('question', instance.question);
+  writeNotNull('quantitative', instance.quantitative);
+  writeNotNull('answer', instance.answer);
   return val;
 }
 

--- a/test/tests/auth/frappe/frappe_auth_controller_test.dart
+++ b/test/tests/auth/frappe/frappe_auth_controller_test.dart
@@ -7,10 +7,11 @@ import '../../../test_manager.dart';
 void main() {
   final skip = false;
   FrappeAuthController frappeAuthController;
-  final mobileNo = '<mobile_number>';
+  final mobileNo = TestManager.mobileNumber;
 
-  final validEmail = '<username>';
-  final validPwd = '<password>';
+  final validUser = TestManager.secondaryUser;
+  final validPwd = TestManager.secondaryUserPwd;
+  final validPin = TestManager.getVariable(EnvVariables.PinNumber);
 
   setUp(() async {
     await TestManager.getTestInstance();
@@ -21,7 +22,7 @@ void main() {
     group('with Incorrect Credentials', () {
       test('should not login successfully with wrong credentials', () async {
         final response =
-            await frappeAuthController.login(validEmail, 'wrong_password');
+            await frappeAuthController.login(validUser, 'wrong_password');
 
         expect(response.isSuccess, false);
         expect(response.httpCode, 401);
@@ -31,7 +32,7 @@ void main() {
 
       test('should not login successfully for non-existing user', () async {
         final response =
-            await frappeAuthController.login('<username>', validPwd);
+            await frappeAuthController.login('nonexisting@abc.com', validPwd);
 
         expect(response.isSuccess, false);
         expect(response.httpCode, 404);
@@ -42,7 +43,7 @@ void main() {
 
     group('with Correct Credentials', () {
       test('should login successfully with correct credentials', () async {
-        final response = await frappeAuthController.login(validEmail, validPwd);
+        final response = await frappeAuthController.login(validUser, validPwd);
         expect(response.isSuccess, true);
         expect(response.httpCode, 200);
         expect(frappeAuthController.isLoggedIn, true);
@@ -57,7 +58,7 @@ void main() {
 
       test('should verify login status for test account as authenticated',
           () async {
-        await frappeAuthController.login(validEmail, validPwd);
+        await frappeAuthController.login(validUser, validPwd);
         final response = await frappeAuthController.checkLogin();
         expect(response.isSuccess, true);
         expect(response.data.loggedIn, true);
@@ -67,15 +68,15 @@ void main() {
 
   group('pinLogin', () {
     test('should successfully login and set the session', () async {
-      final response = await frappeAuthController.pinLogin(validEmail, '<OTP>');
+      final response = await frappeAuthController.pinLogin(validUser, validPin);
 
       expect(response.isSuccess, true);
-      expect(response.data.currentUser, validEmail);
+      expect(response.data.currentUser, validUser);
       expect(frappeAuthController.isLoggedIn, true);
     });
 
     test('should not successfully login for wrong pin', () async {
-      final response = await frappeAuthController.pinLogin(validEmail, '0000');
+      final response = await frappeAuthController.pinLogin(validUser, '0000');
 
       expect(response.isSuccess, false);
       expect(response.error.title, 'Incorrect Pin');
@@ -104,7 +105,7 @@ void main() {
     });
     test('should fail for invalid pin', () async {
       final response =
-          await frappeAuthController.verifyOTP(mobileNo, '<OTP>', false);
+          await frappeAuthController.verifyOTP(mobileNo, '000000', false);
       expect(response.isSuccess, false);
       expect(response.data, isNull);
       expect(response.error.info.httpCode, 401);
@@ -113,7 +114,7 @@ void main() {
     });
     test('should fail for non-existing user/mobile', () async {
       final response =
-          await frappeAuthController.verifyOTP('+9710000000', '<OTP>', false);
+          await frappeAuthController.verifyOTP('+9710000000', '000000', false);
       expect(response.isSuccess, false);
       expect(response.data, isNull);
       expect(response.error.info.httpCode, 404);
@@ -127,7 +128,7 @@ void main() {
 
   group('getCurrentUserRoles', () {
     test('should get the signed in user roles', () async {
-      await frappeAuthController.login(validEmail, validPwd);
+      await frappeAuthController.login(validUser, validPwd);
       final response = await frappeAuthController.getCurrentUserRoles();
 
       expect(response.isSuccess, true);
@@ -144,7 +145,7 @@ void main() {
 
   group('logout', () {
     test('should logout successfully', () async {
-      await frappeAuthController.login(validEmail, validPwd);
+      await frappeAuthController.login(validUser, validPwd);
       expect(frappeAuthController.isLoggedIn, true);
       await frappeAuthController.logout();
       expect(frappeAuthController.isLoggedIn, false);
@@ -153,7 +154,7 @@ void main() {
 
   group('changeUserLanguage', () {
     test('should successfully change the language of current user', () async {
-      await frappeAuthController.login(validEmail, validPwd);
+      await frappeAuthController.login(validUser, validPwd);
       final response = await frappeAuthController.changeUserLanguage('ar');
       expect(response, true);
       expect(frappeAuthController.getSession().lang, 'ar');
@@ -171,7 +172,7 @@ void main() {
   group('clearAuthToken', () {
     test('should clearAuthToken successfully & remove Authorization headers',
         () async {
-      await frappeAuthController.login(validEmail, validPwd);
+      await frappeAuthController.login(validUser, validPwd);
 
       expect(frappeAuthController.getCurrentToken(), isNotNull);
       expect(
@@ -193,7 +194,7 @@ void main() {
 
   group('resetSession', () {
     test('should reset the session to not logged in', () async {
-      await frappeAuthController.login(validEmail, validPwd);
+      await frappeAuthController.login(validUser, validPwd);
       expect(frappeAuthController.getSession().loggedIn, true);
       frappeAuthController.resetSession();
       expect(frappeAuthController.getSession().loggedIn, false);
@@ -202,7 +203,7 @@ void main() {
 
   group('clearCache', () {
     test('should reset currentUserRoles on clearCache', () async {
-      await frappeAuthController.login(validEmail, validPwd);
+      await frappeAuthController.login(validUser, validPwd);
       await frappeAuthController.getCurrentUserRoles();
       expect(frappeAuthController.currentUserRoles.isNotEmpty, true);
       frappeAuthController.clearCache();

--- a/test/tests/backend/frappe/frappe_log_manager_test.dart
+++ b/test/tests/backend/frappe/frappe_log_manager_test.dart
@@ -8,13 +8,14 @@ import '../../../test_manager.dart';
 
 void main() {
   FrappeLogManager log;
+  final validUser = TestManager.primaryUser;
+  final validPwd = TestManager.primaryUserPwd;
+
   setUpAll(() async {
     await TestManager.getTestInstance();
     log = getFrappeLogManager();
     // Login the user to have permission to get the document
-    await getFrappeAuthController().login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']);
+    await getFrappeAuthController().login(validUser, validPwd);
   });
 
   group('Log Manager', () {
@@ -22,7 +23,7 @@ void main() {
       test('logging basic info', () async {
         var response = await log.info(content: 'Test Info 1');
 
-        var logged = response.data;
+        final logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Info');
@@ -32,7 +33,7 @@ void main() {
         var response = await log.info(
             content: 'Test Info 2', tags: ['TAG1', 'TAG2'], title: 'TitleA');
 
-        var logged = response.data;
+        final logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Info');
@@ -51,7 +52,7 @@ void main() {
       test('logging basic error', () async {
         var response = await log.error(content: 'Test error 1');
 
-        var logged = response.data;
+        final logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Error');
@@ -61,7 +62,7 @@ void main() {
         var response = await log.error(
             content: 'Test error 2', tags: ['TAG1', 'TAG2'], title: 'TitleA');
 
-        var logged = response.data;
+        final logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Error');
@@ -80,7 +81,7 @@ void main() {
       test('logging basic warning', () async {
         var response = await log.warning(content: 'Test warning 1');
 
-        var logged = response.data;
+        final logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Warning');
@@ -90,7 +91,7 @@ void main() {
         var response = await log.warning(
             content: 'Test warning 2', tags: ['TAG1', 'TAG2'], title: 'TitleA');
 
-        var logged = response.data;
+        final logged = response.data;
         expect(response.isSuccess, true);
         expect(response.data, isA<FrappeLog>());
         expect(logged?.type, 'Warning');
@@ -108,14 +109,13 @@ void main() {
     group('Request Log', () {
       RequestResponse<User> response;
       setUpAll(() async {
-        response =
-            await getFrappeModelController().getDoc(User(), '<admin_user>');
+        response = await getFrappeModelController().getDoc(User(), validUser);
       });
 
       test('Successful Request Log', () async {
         var r = await log.logRequest(r: response);
         expect(r.isSuccess, true);
-        var logged = r.data;
+        final logged = r.data;
         expect(logged?.type, 'Request');
         expect(logged?.request != null, true);
         expect(logged?.response != null, true);

--- a/test/tests/backend/frappe/frappe_test.dart
+++ b/test/tests/backend/frappe/frappe_test.dart
@@ -6,13 +6,13 @@ import '../../../test_manager.dart';
 
 void main() {
   Frappe frappe;
+  final validUser = TestManager.primaryUser;
+  final validPwd = TestManager.primaryUserPwd;
   setUpAll(() async {
     await TestManager.getTestInstance();
     frappe = getFrappe();
     // Login the user to have permission to get the document
-    await getFrappeAuthController().login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']);
+    await getFrappeAuthController().login(validUser, validPwd);
   });
 
   group('Frappe Versioning', () {
@@ -26,7 +26,7 @@ void main() {
 
   group('FCM Notifications', () {
     test('should register fcm token', () async {
-      var response = await frappe.registerFCMToken('test');
+      var response = await frappe.registerFCMToken('1234567890');
       expect(response.isSuccess, true);
       expect(response.data, 'OK');
     });

--- a/test/tests/defaults/frappe/frappe_defaults_controller_test.dart
+++ b/test/tests/defaults/frappe/frappe_defaults_controller_test.dart
@@ -7,13 +7,15 @@ import '../../../test_manager.dart';
 
 void main() {
   FrappeDefaultsController frappeDefaultsController;
+
+  final validUser = TestManager.primaryUser;
+  final validPwd = TestManager.primaryUserPwd;
+
   setUpAll(() async {
     await TestManager.getTestInstance();
     frappeDefaultsController = getFrappeDefaultsController();
     // Login the user to have permission to get the document
-    await getFrappeAuthController().login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']);
+    await getFrappeAuthController().login(validUser, validPwd);
     // To be used for getDefaults
     await frappeDefaultsController.setDefaults(
         key: 'testing_key', value: 'testing_value');
@@ -24,7 +26,7 @@ void main() {
       final response =
           await frappeDefaultsController.getDefault(key: 'setup_complete');
       expect(response.isSuccess, true);
-      expect(response.data != null, true);
+      expect(response.data, isNotNull);
       expect(response.data, isA<String>());
     });
 
@@ -32,7 +34,7 @@ void main() {
       final response =
           await frappeDefaultsController.getDefault(key: 'non-existing-key');
       expect(response.isSuccess, true);
-      expect(response.data, null);
+      expect(response.data, isNull);
     });
   });
 

--- a/test/tests/meta/frappe/frappe_meta_controller_test.dart
+++ b/test/tests/meta/frappe/frappe_meta_controller_test.dart
@@ -7,18 +7,20 @@ import '../../../test_manager.dart';
 
 void main() {
   FrappeMetaController frappeMetaController;
+
+  final validUser = TestManager.primaryUser;
+  final validPwd = TestManager.primaryUserPwd;
+
   setUpAll(() async {
     await TestManager.getTestInstance();
     frappeMetaController = getFrappeMetaController();
     // Login the user to have permission to get the document
-    await getFrappeAuthController().login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']);
+    await getFrappeAuthController().login(validUser, validPwd);
   });
 
   group('Get Document Count', () {
     test('should get document count successfully', () async {
-      final response = await frappeMetaController.getDocCount(doctype: 'Item');
+      final response = await frappeMetaController.getDocCount(doctype: 'User');
 
       expect(response.isSuccess, true);
       expect(response.data is int, true);
@@ -26,15 +28,15 @@ void main() {
     });
     test('should get document count as 0 if there none', () async {
       final response =
-          await frappeMetaController.getDocCount(doctype: 'Payment Entry');
+          await frappeMetaController.getDocCount(doctype: 'Milestone');
 
       expect(response.isSuccess, true);
       expect(response.data, 0);
     });
-    test('should get document count successfully with Filters', () async {
-      final response =
-          await frappeMetaController.getDocCount(doctype: 'Item', filters: {
-        'name': ['LIKE', '%RED%']
+    test('should get document count successfully with filters', () async {
+      final response = await frappeMetaController
+          .getDocCount(doctype: 'Chat Profile', filters: {
+        'name': ['LIKE', validUser]
       });
 
       expect(response.isSuccess, true);
@@ -44,7 +46,7 @@ void main() {
     test('should throw "InvalidFrappeFilter" for invalid filters', () async {
       expect(
           () async => await frappeMetaController.getDocCount(
-              doctype: 'Item', filters: 'invalid-filter'),
+              doctype: 'User', filters: 'invalid-filter'),
           throwsA(TypeMatcher<InvalidFrappeFilter>()));
     });
 
@@ -60,9 +62,10 @@ void main() {
   });
 
   group('Get Document Info', () {
-    test('should successfully get document info', () async {
+    test('should successfully get document info of an existing document',
+        () async {
       final response = await frappeMetaController.getDocInfo(
-          doctype: 'Item', docname: '1234');
+          doctype: 'User', docname: validUser);
       expect(response.isSuccess, true);
       expect(response.data is FrappeDocInfo, true);
     });
@@ -78,7 +81,7 @@ void main() {
 
     test('should return a failure for non-existing docname', () async {
       final response = await frappeMetaController.getDocInfo(
-          doctype: 'Item', docname: 'NON EXISTING');
+          doctype: 'Renovation Review', docname: 'NON EXISTING');
       expect(response.isSuccess, false);
       expect(response.error.info.httpCode, 404);
       expect(
@@ -87,21 +90,25 @@ void main() {
   });
 
   group('Get Doc Meta', () {
-    test('should successfully get a doctype meta of Item', () async {
-      final response = await frappeMetaController.getDocMeta(doctype: 'Item');
+    test('should successfully get a doctype meta of Renovation Review',
+        () async {
+      final response =
+          await frappeMetaController.getDocMeta(doctype: 'Renovation Review');
       expect(response.isSuccess, true);
-      expect(response.data.name, 'Item');
-      expect(response.data.isSubmittable, false);
+      expect(response.data.name, 'Renovation Review');
+      expect(response.data.isSubmittable, true);
       expect(response.data.isSingle, false);
     });
 
     test(
-        'should successfully get a doctype meta of Item and save it in docTypeCache',
+        'should successfully get a doctype meta of Renovation Review and save it in docTypeCache',
         () async {
-      final response = await frappeMetaController.getDocMeta(doctype: 'Item');
+      final response =
+          await frappeMetaController.getDocMeta(doctype: 'Renovation Review');
       expect(response.isSuccess, true);
-      expect(response.data.name, 'Item');
-      expect(frappeMetaController.docTypeCache['Item'], isA<DocType>());
+      expect(response.data.name, 'Renovation Review');
+      expect(frappeMetaController.docTypeCache['Renovation Review'],
+          isA<DocType>());
       expect(frappeMetaController.docTypeCache.keys.length > 1, true);
     });
 
@@ -116,27 +123,28 @@ void main() {
   group('Get Field Label', () {
     test('should successfully get a field label', () async {
       final response = await frappeMetaController.getFieldLabel(
-          doctype: 'Item', fieldName: 'item_group');
-      expect(response, 'Item Group');
+          doctype: 'Renovation Review', fieldName: 'reviewed_by');
+      expect(response, 'Reviewed By');
     });
 
-    test('should get the standard field for doctype Item', () async {
+    test('should get the standard field for doctype Renovation Review',
+        () async {
       final response = await frappeMetaController.getFieldLabel(
-          doctype: 'Item', fieldName: 'name');
+          doctype: 'Renovation Review', fieldName: 'name');
       expect(response, 'Name');
     });
 
     test('should return the field name as-is if the doctype does not exist ',
         () async {
       final response = await frappeMetaController.getFieldLabel(
-          doctype: 'NON EXISTING', fieldName: 'item_group');
-      expect(response, 'item_group');
+          doctype: 'NON EXISTING', fieldName: 'reviewed_by');
+      expect(response, 'reviewed_by');
     });
 
     test('should return the field name as-is if the field does not exist ',
         () async {
       final response = await frappeMetaController.getFieldLabel(
-          doctype: 'Item', fieldName: 'non_existing_field');
+          doctype: 'Renovation Review', fieldName: 'non_existing_field');
       expect(response, 'non_existing_field');
     });
   });

--- a/test/tests/perm/frappe/frappe_perm_controller_test.dart
+++ b/test/tests/perm/frappe/frappe_perm_controller_test.dart
@@ -9,22 +9,23 @@ void main() {
   FrappePermissionController frappePermissionController;
   FrappeAuthController frappeAuthController;
 
-  final testEmail = '<username>';
-  final testPwd = '<password>';
+  final validUser = TestManager.primaryUser;
+  final validPwd = TestManager.primaryUserPwd;
+
+  final validSecondUser = TestManager.secondaryUser;
+  final validSecondUserPwd = TestManager.secondaryUserPwd;
 
   setUp(() async {
     await TestManager.getTestInstance();
     frappePermissionController = getFrappePermissionController();
     frappeAuthController = getFrappeAuthController();
     // Login the user to have permission to get the document
-    await frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']);
+    await frappeAuthController.login(validUser, validPwd);
   });
 
   group('Load Basic Permission', () {
     test(
-        'should successfully load basic permissions of <admin_user> from the backend',
+        'should successfully load basic permissions of a System Manager user from the backend',
         () async {
       final response = await frappePermissionController.loadBasicPerms();
 
@@ -33,8 +34,9 @@ void main() {
       expect(frappePermissionController.basicPerms, isNotNull);
     });
 
-    test('should successfully load basic permissions of <username>', () async {
-      await frappeAuthController.login(testEmail, testPwd);
+    test('should successfully load basic permissions of a non-System Manager',
+        () async {
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response = await frappePermissionController.loadBasicPerms();
 
@@ -44,15 +46,13 @@ void main() {
 
     //TODO: Check fail cases
 
-    // Re-login to <admin_user> for the rest of the tests.
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    // Re-login to a System Manager user for the rest of the tests.
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('Get Permissions of a doctype', () {
     test(
-        'should get the list of permissions of a doctype successfully for <admin_user>',
+        'should get the list of permissions of a doctype successfully for a System Manager user',
         () async {
       final response =
           await frappePermissionController.getPerm(doctype: 'User');
@@ -67,9 +67,9 @@ void main() {
     });
 
     test(
-        'should get the list of permissions of a doctype successfully for <username>',
+        'should get the list of permissions of a doctype successfully for a non-System Manager user',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response =
           await frappePermissionController.getPerm(doctype: 'User');
@@ -99,27 +99,28 @@ void main() {
       expect(response.data.first.ifOwner, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('hasPerm', () {
-    test('should return true for <admin_user> to create User', () async {
+    test('should return true for a System Manager user to create User',
+        () async {
       final response = await frappePermissionController.hasPerm(
           doctype: 'User', pType: PermissionType.create);
 
       expect(response, true);
     });
 
-    test('should return false for <admin_user> to submit User', () async {
+    test('should return false for a System Manager user to submit User',
+        () async {
       final response = await frappePermissionController.hasPerm(
           doctype: 'User', pType: PermissionType.submit);
 
       expect(response, false);
     });
 
-    test('should return true for <admin_user> to write User with permLevel 1',
+    test(
+        'should return true for a System Manager user to write User with permLevel 1',
         () async {
       final response = await frappePermissionController.hasPerm(
           doctype: 'User', pType: PermissionType.write, permLevel: 1);
@@ -128,7 +129,7 @@ void main() {
     });
 
     test(
-        'should return false for <admin_user> to create User with permLevel 1',
+        'should return false for a System Manager user to create User with permLevel 1',
         () async {
       final response = await frappePermissionController.hasPerm(
           doctype: 'User', pType: PermissionType.create, permLevel: 1);
@@ -150,22 +151,20 @@ void main() {
       expect(response, false);
     });
 
-    test('should return true for create <admin_user> of a specific doctype',
+    test(
+        'should return true for write a System Manager user of a specific doctype',
         () async {
       final response = await frappePermissionController.hasPerm(
-          doctype: 'User',
-          docname: '<admin_user>',
-          pType: PermissionType.create);
+          doctype: 'User', docname: validUser, pType: PermissionType.write);
 
       expect(response, true);
     });
 
-    test('should return false for submit <admin_user> of a specific doctype',
+    test(
+        'should return false for submit a System Manager user of a specific doctype',
         () async {
       final response = await frappePermissionController.hasPerm(
-          doctype: 'User',
-          docname: '<admin_user>',
-          pType: PermissionType.submit);
+          doctype: 'User', docname: validUser, pType: PermissionType.submit);
 
       expect(response, false);
     });
@@ -180,7 +179,8 @@ void main() {
   });
 
   group('hasPerms', () {
-    test('should return true for <admin_user> to create, read and write User',
+    test(
+        'should return true for a System Manager user to create, read and write User',
         () async {
       final response = await frappePermissionController.hasPerms(
           doctype: 'User',
@@ -194,7 +194,7 @@ void main() {
     });
 
     test(
-        'should return false for create, submit, read and write <admin_user> of a specific doctype',
+        'should return false for create, submit, read and write a System Manager user of a specific doctype',
         () async {
       final response =
           await frappePermissionController.hasPerms(doctype: 'User', pTypes: [
@@ -209,7 +209,7 @@ void main() {
   });
 
   group('canRead', () {
-    test('should return true for <admin_user> read on System Settings',
+    test('should return true for a System Manager user read on System Settings',
         () async {
       final response =
           await frappePermissionController.canRead('System Settings');
@@ -217,9 +217,10 @@ void main() {
       expect(response, true);
     });
 
-    test('should return false for <username> read on System Settings',
+    test(
+        'should return false for a non-System Manager user read on System Settings',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response =
           await frappePermissionController.canRead('System Settings');
@@ -227,33 +228,32 @@ void main() {
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canCreate', () {
-    test('should return true for <admin_user> create on User', () async {
+    test('should return true for a System Manager user create on User',
+        () async {
       final response = await frappePermissionController.canCreate('User');
 
       expect(response, true);
     });
 
-    test('should return false for <username> create on Use', () async {
-      await frappeAuthController.login(testEmail, testPwd);
+    test('should return false for a non-System Manager user create on Use',
+        () async {
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response = await frappePermissionController.canCreate('User');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canWrite', () {
-    test('should return true for <admin_user> write on System Settings',
+    test(
+        'should return true for a System Manager user write on System Settings',
         () async {
       final response =
           await frappePermissionController.canWrite('System Settings');
@@ -261,9 +261,10 @@ void main() {
       expect(response, true);
     });
 
-    test('should return false for <username> create on System Settings',
+    test(
+        'should return false for a non-System Manager user create on System Settings',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response =
           await frappePermissionController.canWrite('System Settings');
@@ -271,163 +272,164 @@ void main() {
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canCancel', () {
-    test('should return true for <admin_user> cancel on Sales Invoice',
+    test(
+        'should return true for a System Manager user cancel on Renovation User Agreement',
         () async {
-      final response =
-          await frappePermissionController.canCancel('Sales Invoice');
+      final response = await frappePermissionController
+          .canCancel('Renovation User Agreement');
 
       expect(response, true);
     });
 
-    test('should return false for <username> create on Sales Invoice',
+    test(
+        'should return false for a non-System Manager user create on Renovation User Agreement',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
-      final response =
-          await frappePermissionController.canCancel('Sales Invoice');
+      final response = await frappePermissionController
+          .canCancel('Renovation User Agreement');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canDelete', () {
-    test('should return true for <admin_user> delete on User', () async {
+    test('should return true for a System Manager user delete on User',
+        () async {
       final response = await frappePermissionController.canDelete('User');
 
       expect(response, true);
     });
 
-    test('should return false for <username> delete on User', () async {
-      await frappeAuthController.login(testEmail, testPwd);
+    test('should return false for a non-System Manager user delete on User',
+        () async {
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response = await frappePermissionController.canDelete('User');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canImport', () {
-    test('should return true for <admin_user> import on User', () async {
+    test('should return true for a System Manager user import on User',
+        () async {
       final response = await frappePermissionController.canImport('User');
 
       expect(response, true);
     });
 
-    test('should return false for <username> import on User', () async {
-      await frappeAuthController.login(testEmail, testPwd);
+    test('should return false for a non-System Manager user import on User',
+        () async {
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response = await frappePermissionController.canImport('User');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canExport', () {
-    test('should return true for <admin_user> export on Item Group', () async {
-      final response = await frappePermissionController.canExport('Item Group');
+    test(
+        'should return true for a System Manager user export on Renovation User Agreement',
+        () async {
+      final response = await frappePermissionController
+          .canExport('Renovation User Agreement');
 
       expect(response, true);
     });
 
-    test('should return false for <username> export on Item Group',
+    test(
+        'should return false for a non-System Manager user export on Renovation User Agreement',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
-      final response = await frappePermissionController.canExport('Item Group');
+      final response = await frappePermissionController
+          .canExport('Renovation User Agreement');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canPrint', () {
-    test('should return true for <admin_user> print on Sales Invoice',
+    test(
+        'should return true for a System Manager user print on Renovation User Agreement',
         () async {
-      final response =
-          await frappePermissionController.canPrint('Sales Invoice');
+      final response = await frappePermissionController
+          .canPrint('Renovation User Agreement');
 
       expect(response, true);
     });
 
-    test('should return false for <username> print on Sales Invoice',
+    test(
+        'should return false for a non-System Manager user print on Renovation User Agreement',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
-      final response =
-          await frappePermissionController.canPrint('Sales Invoice');
+      final response = await frappePermissionController
+          .canPrint('Renovation User Agreement');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canEmail', () {
-    test('should return true for <admin_user> email on User', () async {
+    test('should return true for a System Manager user email on User',
+        () async {
       final response = await frappePermissionController.canEmail('User');
 
       expect(response, true);
     });
 
-    test('should return false for <username> print on User', () async {
-      await frappeAuthController.login(testEmail, testPwd);
+    test('should return false for a non-System Manager user print on User',
+        () async {
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response = await frappePermissionController.canEmail('User');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canSearch', () {
-    test('should return true for <admin_user> search on Bank', () async {
+    test('should return true for a System Manager user search on Bank',
+        () async {
       final response = await frappePermissionController.canSearch('Bank');
 
       expect(response, true);
     });
 
-    test('should return false for <username> search on Bank', () async {
-      await frappeAuthController.login(testEmail, testPwd);
+    test('should return false for a non-System Manager user search on Bank',
+        () async {
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response = await frappePermissionController.canSearch('Bank');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canGetReport', () {
     test(
-        'should return true for <admin_user> get report on Renovation User Agreement',
+        'should return true for a System Manager user get report on Renovation User Agreement',
         () async {
       final response = await frappePermissionController
           .canGetReport('Renovation User Agreement');
@@ -436,9 +438,9 @@ void main() {
     });
 
     test(
-        'should return false for <username> get report on Renovation User Agreement',
+        'should return false for a non-System Manager user get report on Renovation User Agreement',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response = await frappePermissionController
           .canGetReport('Renovation User Agreement');
@@ -446,14 +448,12 @@ void main() {
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canSetUserPermission', () {
     test(
-        'should return false for <admin_user> setting user permission on User',
+        'should return false for a System Manager user setting user permission on User',
         () async {
       final response =
           await frappePermissionController.canSetUserPermissions('User');
@@ -462,9 +462,9 @@ void main() {
     });
 
     test(
-        'should return false for <username> setting user permission on User',
+        'should return false for a non-System Manager user setting user permission on User',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       final response =
           await frappePermissionController.canSetUserPermissions('User');
@@ -472,127 +472,121 @@ void main() {
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canSubmit', () {
     test(
-        'should return false for <admin_user> submit on Sales Invoice because doctypePerms is not loaded',
+        'should return false for a System Manager user submit on Renovation User Agreement because doctypePerms is not loaded',
         () async {
-      final response =
-          await frappePermissionController.canSubmit('Sales Invoice');
+      final response = await frappePermissionController
+          .canSubmit('Renovation User Agreement');
 
       expect(response, false);
     });
 
     test(
-        'should return true for <admin_user> submit on Sales Invoice given doctypePerms is loaded',
+        'should return true for a System Manager user submit on Renovation User Agreement given doctypePerms is loaded',
         () async {
       await frappePermissionController.hasPerm(
-          doctype: 'Sales Invoice', pType: PermissionType.submit);
-      final response =
-          await frappePermissionController.canSubmit('Sales Invoice');
+          doctype: 'Renovation User Agreement', pType: PermissionType.submit);
+      final response = await frappePermissionController
+          .canSubmit('Renovation User Agreement');
 
       expect(response, true);
     });
 
-    test('should return false for <username> submit on Sales Invoice',
+    test(
+        'should return false for a non-System Manager user submit on Renovation User Agreement',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       await frappePermissionController.hasPerm(
-          doctype: 'Sales Invoice', pType: PermissionType.submit);
+          doctype: 'Renovation User Agreement', pType: PermissionType.submit);
 
-      final response =
-          await frappePermissionController.canSubmit('Sales Invoice');
+      final response = await frappePermissionController
+          .canSubmit('Renovation User Agreement');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canAmend', () {
     test(
-        'should return false for <admin_user> amend on Sales Invoice because doctypePerms is not loaded',
+        'should return false for a System Manager user amend on Renovation User Agreement because doctypePerms is not loaded',
         () async {
-      final response =
-          await frappePermissionController.canAmend('Sales Invoice');
+      final response = await frappePermissionController
+          .canAmend('Renovation User Agreement');
 
       expect(response, false);
     });
 
     test(
-        'should return true for <admin_user> amend on Sales Invoice given doctypePerms is loaded',
+        'should return true for a System Manager user amend on Renovation User Agreement given doctypePerms is loaded',
         () async {
       await frappePermissionController.hasPerm(
-          doctype: 'Sales Invoice', pType: PermissionType.amend);
-      final response =
-          await frappePermissionController.canAmend('Sales Invoice');
+          doctype: 'Renovation User Agreement', pType: PermissionType.amend);
+      final response = await frappePermissionController
+          .canAmend('Renovation User Agreement');
 
       expect(response, true);
     });
 
-    test('should return false for <username> amend on Sales Invoice',
+    test(
+        'should return false for a non-System Manager user amend on Renovation User Agreement',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       await frappePermissionController.hasPerm(
-          doctype: 'Sales Invoice', pType: PermissionType.amend);
+          doctype: 'Renovation User Agreement', pType: PermissionType.amend);
 
-      final response =
-          await frappePermissionController.canAmend('Sales Invoice');
+      final response = await frappePermissionController
+          .canAmend('Renovation User Agreement');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   group('canRecursiveDelete', () {
     test(
-        'should return false for <admin_user> recursive delete on Sales Invoice because doctypePerms is not loaded',
+        'should return false for a System Manager user recursive delete on Renovation User Agreement because doctypePerms is not loaded',
         () async {
-      final response =
-          await frappePermissionController.canRecursiveDelete('Sales Invoice');
+      final response = await frappePermissionController
+          .canRecursiveDelete('Renovation User Agreement');
 
       expect(response, false);
     });
 
     test(
-        'should return false for <admin_user> recursive delete on Sales Invoice given doctypePerms is loaded',
+        'should return false for a System Manager user recursive delete on Renovation User Agreement given doctypePerms is loaded',
         () async {
       await frappePermissionController.hasPerm(
-          doctype: 'Sales Invoice', pType: PermissionType.amend);
-      final response =
-          await frappePermissionController.canRecursiveDelete('Sales Invoice');
+          doctype: 'Renovation User Agreement', pType: PermissionType.amend);
+      final response = await frappePermissionController
+          .canRecursiveDelete('Renovation User Agreement');
 
       expect(response, false);
     });
 
     test(
-        'should return false for <username> recursive delete on Sales Invoice',
+        'should return false for a non-System Manager user recursive delete on Renovation User Agreement',
         () async {
-      await frappeAuthController.login(testEmail, testPwd);
+      await frappeAuthController.login(validSecondUser, validSecondUserPwd);
 
       await frappePermissionController.hasPerm(
-          doctype: 'Sales Invoice', pType: PermissionType.amend);
+          doctype: 'Renovation User Agreement', pType: PermissionType.amend);
 
-      final response =
-          await frappePermissionController.canRecursiveDelete('Sales Invoice');
+      final response = await frappePermissionController
+          .canRecursiveDelete('Renovation User Agreement');
 
       expect(response, false);
     });
 
-    tearDownAll(() => frappeAuthController.login(
-        TestManager.getTestUserCredentials()['email'],
-        TestManager.getTestUserCredentials()['password']));
+    tearDownAll(() => frappeAuthController.login(validUser, validPwd));
   });
 
   tearDownAll(() async => await frappeAuthController.logout());


### PR DESCRIPTION
Fixes:
- Fixed casting issue in getDocMeta
- Fixed registerFCMToken response
- Fixed some imports referencing package
- Removed unused imports

Modifications:
- Added TagLink model
- Modified getTags to use getList if frappe version >=12
- Add BlockModule child doctype to User
- Minor modification in documentation
- Exclude .g files in test folder (analysis_options.yaml)

Tests:
- Variables are now fetched from System environment variables (Platform.environment)
- Added some tests
- Changed doctypes used in tests
- Added Setup/Teardown for some test groups
- Minor refactoring