### PR TITLE
feat: Added ability to use cookies for sessions

### DIFF
--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -37,10 +37,16 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
   /// The header to which the token is prepended to according to the requirement of the backend.
   static const String TOKEN_HEADER = 'JWTToken';
 
+  /// Whether to authenticate using JWT. If set to false, will use cookies.
+  bool _useJwt = false;
+
   /// Returns the current JWT token formatted as `TOKEN_HEADER token`.
   @override
   String getCurrentToken() =>
       currentToken != null ? '$TOKEN_HEADER $currentToken' : null;
+
+  /// Set the value for whether to use JWT authentication
+  void enableJWT(bool useJwt) => _useJwt = useJwt;
 
   /// Checks the session's status (Whether the user is logged in or not) and returns it as [FrappeSessionStatusInfo].
   ///
@@ -77,7 +83,11 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
         url: config.hostUrl + '/api/method/login',
         method: HttpMethod.POST,
         contentType: ContentTypeLiterals.APPLICATION_X_WWW_FORM_URLENCODED,
-        data: <String, dynamic>{'usr': email, 'pwd': password, 'use_jwt': 1},
+        data: <String, dynamic>{
+          'usr': email,
+          'pwd': password,
+          'use_jwt': _useJwt ? 1 : 0
+        },
         isFrappeResponse: false);
 
     SessionStatusInfo sessionStatusInfo;
@@ -189,7 +199,7 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
           'mobile': mobileNo,
           'pin': otp,
           'loginToUser': loginToUser ? 1 : 0,
-          'use_jwt': 1
+          'use_jwt': _useJwt ? 1 : 0
         });
 
     VerifyOTPResponse verifyOTPResponse;

--- a/lib/src/core/errors.dart
+++ b/lib/src/core/errors.dart
@@ -70,3 +70,10 @@ class JSONAbleMethodsNotImplemented extends Error {
   @override
   String toString() => 'fromJson() and/or toJson() are not implemented';
 }
+
+/// Thrown when Cookie directory is not set while useJWT is set to `false`
+class CookieDirNotSet extends Error {
+  @override
+  String toString() =>
+      'Cookie directory is not set, please set a valid cookie directory';
+}

--- a/lib/src/core/renovation.dart
+++ b/lib/src/core/renovation.dart
@@ -2,6 +2,8 @@ import 'dart:core';
 
 import 'package:logger/logger.dart';
 import 'package:pedantic/pedantic.dart';
+import 'package:renovation_core/core.dart';
+import 'package:renovation_core/src/core/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../auth/auth.controller.dart';
@@ -100,6 +102,8 @@ class Renovation {
       {RenovationBackend backend = RenovationBackend.frappe,
       String clientId,
       K sessionStatusInfo,
+      String cookieDir,
+      bool useJWT = false,
       bool isBenchEnabled = false,
       bool disableLog = false,
       Logger customLogger}) async {
@@ -127,6 +131,18 @@ class Renovation {
       translate = FrappeTranslationController(config);
       auth = FrappeAuthController(config,
           sessionStatusInfo: sessionStatusInfo as FrappeSessionStatusInfo);
+
+      // Manage sessions using cookies instead of JWT
+      if (!useJWT) {
+        if (cookieDir != null) {
+          Request.setupPersistentCookie(cookieDir);
+        } else {
+          throw CookieDirNotSet();
+        }
+      } else {
+        getFrappeAuthController().enableJWT(true);
+      }
+
       model = FrappeModelController(config);
       meta = FrappeMetaController(config);
       perm = FrappePermissionController(config);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   rxdart: ^0.23.1
   socket_io_client: ^0.9.8
   dio: ^3.0.8
+  dio_cookie_manager: ^1.0.0
   path: ^1.6.4
   logger: ^0.8.3
   meta: ^1.1.8

--- a/test/test_manager.dart
+++ b/test/test_manager.dart
@@ -12,7 +12,7 @@ class TestManager {
       renovation = Renovation();
 
       await renovation.init(_envVariables[EnvVariables.HostURL],
-          disableLog: true);
+          useJWT: true, disableLog: true);
     }
     return renovation;
   }


### PR DESCRIPTION
When initializing renovation either specify `useJwt` as true or set the cookie directory `cookieDir` to use cookies.

## Using cookies
```dart
  final renovation = Renovation();

  await renovation.init(hostUrl,
      cookieDir:
          (await getApplicationDocumentsDirectory()).path + './.cookies/');
```

## Using JWT

```dart
  final renovation = Renovation();

  await renovation.init(hostUrl, useJWT: true);
```