### PR TITLE
feat: Change & Forget Password

### DIFF
--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -88,6 +88,8 @@ abstract class AuthController<K extends SessionStatusInfo>
   Future<RequestResponse<bool>> changePassword(
       {@required String oldPassword, @required String newPassword});
 
+  Future<ResetPasswordInfo> getPasswordResetInfo();
+
   /// Logs out the current user.
   Future<RequestResponse<dynamic>> logout();
 

--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -90,6 +90,8 @@ abstract class AuthController<K extends SessionStatusInfo>
 
   Future<ResetPasswordInfo> getPasswordResetInfo();
 
+  Future<RequestResponse<dynamic>> generatePasswordResetOTP();
+
   /// Logs out the current user.
   Future<RequestResponse<dynamic>> logout();
 

--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -92,6 +92,8 @@ abstract class AuthController<K extends SessionStatusInfo>
 
   Future<RequestResponse<dynamic>> generatePasswordResetOTP();
 
+  Future<RequestResponse<dynamic>> verifyPasswordResetOTP();
+
   /// Logs out the current user.
   Future<RequestResponse<dynamic>> logout();
 

--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -55,7 +55,6 @@ abstract class AuthController<K extends SessionStatusInfo>
   /// result.calcTime : how long it took to calculate an answer in milliseconds.
   Result estimatePassword(String password);
 
-
   /// Logs in the user (if successful) using [email] & [password].
   ///
   /// Returns the [SessionStatusInfo] whether successful or not, wrapped within [RequestResponse].
@@ -82,6 +81,12 @@ abstract class AuthController<K extends SessionStatusInfo>
 
   /// Returns an array of roles assigned to the currently logged in user.
   Future<RequestResponse<List<String>>> getCurrentUserRoles();
+
+  /// Changes the password of the currently logged in user.
+  ///
+  /// Validates the old (current) password before changing it.
+  Future<RequestResponse<bool>> changePassword(
+      {@required String oldPassword, @required String newPassword});
 
   /// Logs out the current user.
   Future<RequestResponse<dynamic>> logout();

--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -89,7 +89,7 @@ abstract class AuthController<K extends SessionStatusInfo>
       {@required String oldPassword, @required String newPassword});
 
   /// Gets the password possible reset methods & hints about these methods
-  Future<ResetPasswordInfo> getPasswordResetInfo();
+  Future<RequestResponse<dynamic>> getPasswordResetInfo();
 
   /// Generates the OTP and sends it through the chosen medium.
   ///

--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -94,6 +94,8 @@ abstract class AuthController<K extends SessionStatusInfo>
 
   Future<RequestResponse<dynamic>> verifyPasswordResetOTP();
 
+  Future<RequestResponse<dynamic>> updatePasswordWithToken();
+
   /// Logs out the current user.
   Future<RequestResponse<dynamic>> logout();
 

--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -88,12 +88,22 @@ abstract class AuthController<K extends SessionStatusInfo>
   Future<RequestResponse<bool>> changePassword(
       {@required String oldPassword, @required String newPassword});
 
+  /// Gets the password possible reset methods & hints about these methods
   Future<ResetPasswordInfo> getPasswordResetInfo();
 
+  /// Generates the OTP and sends it through the chosen medium.
+  ///
+  /// This is the first step for resetting a forgotten password.
   Future<RequestResponse<dynamic>> generatePasswordResetOTP();
 
+  /// Verifies the OTP sent through [generatePasswordResetOTP].
+  ///
+  /// This is the second step for resetting a forgotten password.
   Future<RequestResponse<dynamic>> verifyPasswordResetOTP();
 
+  /// Updates (resets) the password to the chosen password.
+  ///
+  /// The final step in the resetting of a forgotten password.
   Future<RequestResponse<dynamic>> updatePasswordWithToken();
 
   /// Logs out the current user.

--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -492,6 +492,12 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     }
   }
 
+  /// Gets the password possible reset methods & hints about these methods.
+  ///
+  /// The response is based on [ResetPasswordInfo] model.
+  ///
+  /// The [type] represents the type of the id such as email or mobile.
+  /// The [id] is the actual id such as "abc@example.com" if email.
   @override
   Future<ResetPasswordInfo> getPasswordResetInfo({
     @required RESET_ID_TYPE type,
@@ -520,6 +526,9 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     return null;
   }
 
+  /// Generates the OTP and sends it through the chosen [medium] and [mediumId].
+  ///
+  /// This is the first step for resetting a forgotten password.
   @override
   Future<RequestResponse<GenerateResetOTPResponse>> generatePasswordResetOTP({
     @required RESET_ID_TYPE idType,
@@ -566,6 +575,9 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     return RequestResponse.fail(response.error);
   }
 
+  /// Verifies the [otp] sent through [generatePasswordResetOTP].
+  ///
+  /// This is the second step for resetting a forgotten password.
   @override
   Future<RequestResponse<VerifyResetOTPResponse>> verifyPasswordResetOTP({
     @required RESET_ID_TYPE idType,
@@ -615,6 +627,9 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     return RequestResponse.fail(response.error);
   }
 
+  /// Updates (resets) the password to the chosen password by passing the [resetToken].
+  ///
+  /// The final step in the resetting of a forgotten password.
   @override
   Future<RequestResponse<UpdatePasswordResponse>> updatePasswordWithToken({
     @required String resetToken,

--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:enum_to_string/enum_to_string.dart';
 import 'package:meta/meta.dart';
 import 'package:zxcvbn/src/result.dart';
 import 'package:zxcvbn/zxcvbn.dart';
@@ -489,6 +490,34 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
       return RequestResponse.fail(handleError('change_pwd', response.error))
         ..data = false;
     }
+  }
+
+  @override
+  Future<ResetPasswordInfo> getPasswordResetInfo({
+    @required RESET_ID_TYPE type,
+    @required String id,
+  }) async {
+    assert(id != null && id.isNotEmpty, "ID can't be empty");
+    assert(type != null, "ID type can't be null");
+
+    final typeAsString = EnumToString.parse(type);
+
+    final response = await Request.initiateRequest(
+        url: config.hostUrl,
+        method: HttpMethod.POST,
+        contentType: ContentTypeLiterals.APPLICATION_JSON,
+        data: <String, dynamic>{
+          'cmd': 'renovation_core.utils.forgot_pwd.get_reset_info',
+          'id_type': typeAsString,
+          'id': id
+        });
+
+    if (response.isSuccess) {
+      if (response.data.message != null) {
+        return ResetPasswordInfo.fromJson(response.data.message);
+      }
+    }
+    return null;
   }
 
   /// Removes [currentToken] and removes the Authorization header from [RequestOptions]

--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -499,7 +499,7 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
   /// The [type] represents the type of the id such as email or mobile.
   /// The [id] is the actual id such as "abc@example.com" if email.
   @override
-  Future<ResetPasswordInfo> getPasswordResetInfo({
+  Future<RequestResponse<ResetPasswordInfo>> getPasswordResetInfo({
     @required RESET_ID_TYPE type,
     @required String id,
   }) async {
@@ -520,10 +520,12 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
 
     if (response.isSuccess) {
       if (response.data.message != null) {
-        return ResetPasswordInfo.fromJson(response.data.message);
+        return RequestResponse.success(
+            ResetPasswordInfo.fromJson(response.data.message),
+            rawResponse: response.rawResponse);
       }
     }
-    return null;
+    return RequestResponse.fail(response.error);
   }
 
   /// Generates the OTP and sends it through the chosen [medium] and [mediumId].
@@ -783,7 +785,7 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
               ..info = (error.info
                 ..cause = 'Wrong old password'
                 ..suggestion =
-                    'Check that the current password, or reset the password');
+                    'Check that the current password is correct, or reset the password');
           } else if (error.info.httpCode == 417 &&
               (error.info.data.serverMessages as String)
                   .contains('Invalid Password')) {

--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -615,6 +615,46 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     return RequestResponse.fail(response.error);
   }
 
+  @override
+  Future<RequestResponse<UpdatePasswordResponse>> updatePasswordWithToken({
+    @required String resetToken,
+    @required String newPassword,
+  }) async {
+    assert(resetToken != null && resetToken.isNotEmpty,
+        "Reset Token can't be empty");
+
+    assert(newPassword != null && newPassword.isNotEmpty,
+        "Password can't be empty");
+
+    final response = await Request.initiateRequest(
+        url: config.hostUrl,
+        method: HttpMethod.POST,
+        contentType: ContentTypeLiterals.APPLICATION_JSON,
+        data: <String, dynamic>{
+          'cmd': 'renovation_core.utils.forgot_pwd.update_password',
+          'reset_token': resetToken,
+          'new_password': newPassword
+        });
+
+    if (response.isSuccess) {
+      final updateResponse =
+          UpdatePasswordResponse.fromJson(response.data.message);
+
+      if (updateResponse.updated) {
+        return RequestResponse.success(updateResponse,
+            rawResponse: response.rawResponse);
+      } else {
+        return RequestResponse.fail(
+          ErrorDetail(
+            title: updateResponse.reason,
+            info: Information(httpCode: 400),
+          ),
+        )..data = updateResponse;
+      }
+    }
+    return RequestResponse.fail(response.error);
+  }
+
   /// Removes [currentToken] and removes the Authorization header from [RequestOptions]
   @override
   @protected

--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -562,6 +562,51 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     return RequestResponse.fail(response.error);
   }
 
+  @override
+  Future<RequestResponse<VerifyResetOTPResponse>> verifyPasswordResetOTP({
+    @required RESET_ID_TYPE idType,
+    @required String id,
+    @required OTP_MEDIUM medium,
+    @required String mediumId,
+    @required String otp,
+  }) async {
+    assert(id != null && id.isNotEmpty, "ID can't be empty");
+    assert(idType != null, "ID type can't be null");
+    assert(mediumId != null && mediumId.isNotEmpty, "Medium ID can't be empty");
+    assert(medium != null, "Medium can't be null");
+    assert(otp != null && otp.isNotEmpty, "OTP can't be empty");
+
+    final idTypeAsString = EnumToString.parse(idType);
+    final mediumAsString = EnumToString.parse(medium);
+
+    final response = await Request.initiateRequest(
+        url: config.hostUrl,
+        method: HttpMethod.POST,
+        contentType: ContentTypeLiterals.APPLICATION_JSON,
+        data: <String, dynamic>{
+          'cmd': 'renovation_core.utils.forgot_pwd.verify_otp',
+          'id_type': idTypeAsString,
+          'id': id,
+          'medium': mediumAsString,
+          'medium_id': mediumId,
+          'otp': otp
+        });
+
+    if (response.isSuccess) {
+      final otpResponse =
+          VerifyResetOTPResponse.fromJson(response.data.message);
+
+      if (otpResponse.verified) {
+        return RequestResponse.success(otpResponse,
+            rawResponse: response.rawResponse);
+      } else {
+        return RequestResponse.fail(ErrorDetail(title: otpResponse.reason))
+          ..data = otpResponse;
+      }
+    }
+    return RequestResponse.fail(response.error);
+  }
+
   /// Removes [currentToken] and removes the Authorization header from [RequestOptions]
   @override
   @protected

--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -555,8 +555,12 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
         return RequestResponse.success(otpResponse,
             rawResponse: response.rawResponse);
       } else {
-        return RequestResponse.fail(ErrorDetail(title: otpResponse.reason))
-          ..data = otpResponse;
+        return RequestResponse.fail(
+          ErrorDetail(
+            title: otpResponse.reason,
+            info: Information(httpCode: 400),
+          ),
+        )..data = otpResponse;
       }
     }
     return RequestResponse.fail(response.error);
@@ -600,8 +604,12 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
         return RequestResponse.success(otpResponse,
             rawResponse: response.rawResponse);
       } else {
-        return RequestResponse.fail(ErrorDetail(title: otpResponse.reason))
-          ..data = otpResponse;
+        return RequestResponse.fail(
+          ErrorDetail(
+            title: otpResponse.reason,
+            info: Information(httpCode: 400),
+          ),
+        )..data = otpResponse;
       }
     }
     return RequestResponse.fail(response.error);

--- a/lib/src/auth/frappe/interfaces.dart
+++ b/lib/src/auth/frappe/interfaces.dart
@@ -206,5 +206,28 @@ class GenerateResetOTPResponse extends JSONAble {
   Map<String, dynamic> toJson() => _$GenerateResetOTPResponseToJson(this);
 }
 
+@JsonSerializable()
+class VerifyResetOTPResponse extends JSONAble {
+  VerifyResetOTPResponse();
+
+  factory VerifyResetOTPResponse.fromJson(Map<String, dynamic> json) =>
+      _$VerifyResetOTPResponseFromJson(json);
+
+  @JsonKey(fromJson: FrappeDocFieldConverter.checkToBool)
+  bool verified;
+
+  @JsonKey(name: 'reset_token')
+  String resetToken;
+
+  String reason;
+
+  @override
+  T fromJson<T>(Map<String, dynamic> json) =>
+      VerifyResetOTPResponse.fromJson(json) as T;
+
+  @override
+  Map<String, dynamic> toJson() => _$VerifyResetOTPResponseToJson(this);
+}
+
 enum RESET_ID_TYPE { mobile, email }
 enum OTP_MEDIUM { email, sms }

--- a/lib/src/auth/frappe/interfaces.dart
+++ b/lib/src/auth/frappe/interfaces.dart
@@ -145,3 +145,45 @@ class BlockModule extends FrappeDocument {
   @override
   Map<String, dynamic> toJson() => _$BlockModuleToJson(this);
 }
+
+@JsonSerializable()
+class ResetPasswordInfo extends JSONAble {
+  ResetPasswordInfo();
+
+  factory ResetPasswordInfo.fromJson(Map<String, dynamic> json) =>
+      _$ResetPasswordInfoFromJson(json);
+
+  @JsonKey(name: 'has_medium', fromJson: FrappeDocFieldConverter.checkToBool)
+  bool hasMedium;
+
+  List<String> medium;
+
+  ResetInfoHint hints;
+
+  @override
+  T fromJson<T>(Map<String, dynamic> json) =>
+      ResetPasswordInfo.fromJson(json) as T;
+
+  @override
+  Map<String, dynamic> toJson() => _$ResetPasswordInfoToJson(this);
+}
+
+@JsonSerializable()
+class ResetInfoHint extends JSONAble {
+  ResetInfoHint();
+
+  factory ResetInfoHint.fromJson(Map<String, dynamic> json) =>
+      _$ResetInfoHintFromJson(json);
+
+  String email;
+
+  String sms;
+
+  @override
+  T fromJson<T>(Map<String, dynamic> json) => ResetInfoHint.fromJson(json) as T;
+
+  @override
+  Map<String, dynamic> toJson() => _$ResetInfoHintToJson(this);
+}
+
+enum RESET_ID_TYPE { mobile, email }

--- a/lib/src/auth/frappe/interfaces.dart
+++ b/lib/src/auth/frappe/interfaces.dart
@@ -186,4 +186,25 @@ class ResetInfoHint extends JSONAble {
   Map<String, dynamic> toJson() => _$ResetInfoHintToJson(this);
 }
 
+@JsonSerializable()
+class GenerateResetOTPResponse extends JSONAble {
+  GenerateResetOTPResponse();
+
+  factory GenerateResetOTPResponse.fromJson(Map<String, dynamic> json) =>
+      _$GenerateResetOTPResponseFromJson(json);
+
+  @JsonKey(fromJson: FrappeDocFieldConverter.checkToBool)
+  bool sent;
+
+  String reason;
+
+  @override
+  T fromJson<T>(Map<String, dynamic> json) =>
+      GenerateResetOTPResponse.fromJson(json) as T;
+
+  @override
+  Map<String, dynamic> toJson() => _$GenerateResetOTPResponseToJson(this);
+}
+
 enum RESET_ID_TYPE { mobile, email }
+enum OTP_MEDIUM { email, sms }

--- a/lib/src/auth/frappe/interfaces.dart
+++ b/lib/src/auth/frappe/interfaces.dart
@@ -229,5 +229,25 @@ class VerifyResetOTPResponse extends JSONAble {
   Map<String, dynamic> toJson() => _$VerifyResetOTPResponseToJson(this);
 }
 
+@JsonSerializable()
+class UpdatePasswordResponse extends JSONAble {
+  UpdatePasswordResponse();
+
+  factory UpdatePasswordResponse.fromJson(Map<String, dynamic> json) =>
+      _$UpdatePasswordResponseFromJson(json);
+
+  @JsonKey(fromJson: FrappeDocFieldConverter.checkToBool)
+  bool updated;
+
+  String reason;
+
+  @override
+  T fromJson<T>(Map<String, dynamic> json) =>
+      UpdatePasswordResponse.fromJson(json) as T;
+
+  @override
+  Map<String, dynamic> toJson() => _$UpdatePasswordResponseToJson(this);
+}
+
 enum RESET_ID_TYPE { mobile, email }
 enum OTP_MEDIUM { email, sms }

--- a/lib/src/auth/frappe/interfaces.g.dart
+++ b/lib/src/auth/frappe/interfaces.g.dart
@@ -238,3 +238,47 @@ Map<String, dynamic> _$BlockModuleToJson(BlockModule instance) {
   writeNotNull('module', instance.module);
   return val;
 }
+
+ResetPasswordInfo _$ResetPasswordInfoFromJson(Map<String, dynamic> json) {
+  return ResetPasswordInfo()
+    ..hasMedium = FrappeDocFieldConverter.checkToBool(json['has_medium'] as int)
+    ..medium = (json['medium'] as List)?.map((e) => e as String)?.toList()
+    ..hints = json['hints'] == null
+        ? null
+        : ResetInfoHint.fromJson(json['hints'] as Map<String, dynamic>);
+}
+
+Map<String, dynamic> _$ResetPasswordInfoToJson(ResetPasswordInfo instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('has_medium', instance.hasMedium);
+  writeNotNull('medium', instance.medium);
+  writeNotNull('hints', instance.hints?.toJson());
+  return val;
+}
+
+ResetInfoHint _$ResetInfoHintFromJson(Map<String, dynamic> json) {
+  return ResetInfoHint()
+    ..email = json['email'] as String
+    ..sms = json['sms'] as String;
+}
+
+Map<String, dynamic> _$ResetInfoHintToJson(ResetInfoHint instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('email', instance.email);
+  writeNotNull('sms', instance.sms);
+  return val;
+}

--- a/lib/src/auth/frappe/interfaces.g.dart
+++ b/lib/src/auth/frappe/interfaces.g.dart
@@ -304,3 +304,27 @@ Map<String, dynamic> _$GenerateResetOTPResponseToJson(
   writeNotNull('reason', instance.reason);
   return val;
 }
+
+VerifyResetOTPResponse _$VerifyResetOTPResponseFromJson(
+    Map<String, dynamic> json) {
+  return VerifyResetOTPResponse()
+    ..verified = FrappeDocFieldConverter.checkToBool(json['verified'] as int)
+    ..resetToken = json['reset_token'] as String
+    ..reason = json['reason'] as String;
+}
+
+Map<String, dynamic> _$VerifyResetOTPResponseToJson(
+    VerifyResetOTPResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('verified', instance.verified);
+  writeNotNull('reset_token', instance.resetToken);
+  writeNotNull('reason', instance.reason);
+  return val;
+}

--- a/lib/src/auth/frappe/interfaces.g.dart
+++ b/lib/src/auth/frappe/interfaces.g.dart
@@ -282,3 +282,25 @@ Map<String, dynamic> _$ResetInfoHintToJson(ResetInfoHint instance) {
   writeNotNull('sms', instance.sms);
   return val;
 }
+
+GenerateResetOTPResponse _$GenerateResetOTPResponseFromJson(
+    Map<String, dynamic> json) {
+  return GenerateResetOTPResponse()
+    ..sent = FrappeDocFieldConverter.checkToBool(json['sent'] as int)
+    ..reason = json['reason'] as String;
+}
+
+Map<String, dynamic> _$GenerateResetOTPResponseToJson(
+    GenerateResetOTPResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('sent', instance.sent);
+  writeNotNull('reason', instance.reason);
+  return val;
+}

--- a/lib/src/auth/frappe/interfaces.g.dart
+++ b/lib/src/auth/frappe/interfaces.g.dart
@@ -328,3 +328,25 @@ Map<String, dynamic> _$VerifyResetOTPResponseToJson(
   writeNotNull('reason', instance.reason);
   return val;
 }
+
+UpdatePasswordResponse _$UpdatePasswordResponseFromJson(
+    Map<String, dynamic> json) {
+  return UpdatePasswordResponse()
+    ..updated = FrappeDocFieldConverter.checkToBool(json['updated'] as int)
+    ..reason = json['reason'] as String;
+}
+
+Map<String, dynamic> _$UpdatePasswordResponseToJson(
+    UpdatePasswordResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('updated', instance.updated);
+  writeNotNull('reason', instance.reason);
+  return val;
+}


### PR DESCRIPTION
This PR adds two new capabilities for managing a user's password, i.e: _Change_ and _Forgot_ password.

**Changing Password** involves one method which is passing the old and new password, and if the password validate successfully, the password is changed. This won't invalidate the current session of the user.

**Forget Password** involves multiple methods:
- Get reset info (optional)
- Generate OTP
- Verify OTP
- Set New Password

**Tasks**

- [x] Implement change password method
- [x] Implement getting reset info method + model for reset info
- [x] Implement generate OTP method
- [x] Implement verify OTP method
- [x] Implement update password method
- [x] Documentation