### PR TITLE
Several fixes

### DIFF
--- a/lib/src/auth/auth.controller.dart
+++ b/lib/src/auth/auth.controller.dart
@@ -131,7 +131,7 @@ abstract class AuthController<K extends SessionStatusInfo>
   K getSession() => sessionStatus.value;
 
   /// Returns a boolean whether the current user is logged in.
-  bool get isLoggedIn => getSession().loggedIn;
+  bool get isLoggedIn => getSession()?.loggedIn ?? false;
 
   /// Sets the token (JWT).
   @protected

--- a/lib/src/auth/frappe/frappe.auth.controller.dart
+++ b/lib/src/auth/frappe/frappe.auth.controller.dart
@@ -462,6 +462,8 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     @required String oldPassword,
     @required String newPassword,
   }) async {
+    await getFrappe().checkAppInstalled(features: ['changePassword']);
+
     assert(
         oldPassword != null &&
             oldPassword.isNotEmpty &&
@@ -503,6 +505,8 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     @required RESET_ID_TYPE type,
     @required String id,
   }) async {
+    await getFrappe().checkAppInstalled(features: ['getPasswordResetInfo']);
+
     assert(id != null && id.isNotEmpty, "ID can't be empty");
     assert(type != null, "ID type can't be null");
 
@@ -538,6 +542,8 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     @required OTP_MEDIUM medium,
     @required String mediumId,
   }) async {
+    await getFrappe().checkAppInstalled(features: ['generatePasswordResetOTP']);
+
     assert(id != null && id.isNotEmpty, "ID can't be empty");
     assert(idType != null, "ID type can't be null");
     assert(mediumId != null && mediumId.isNotEmpty, "Medium ID can't be empty");
@@ -588,6 +594,8 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     @required String mediumId,
     @required String otp,
   }) async {
+    await getFrappe().checkAppInstalled(features: ['verifyPasswordResetOTP']);
+
     assert(id != null && id.isNotEmpty, "ID can't be empty");
     assert(idType != null, "ID type can't be null");
     assert(mediumId != null && mediumId.isNotEmpty, "Medium ID can't be empty");
@@ -637,6 +645,8 @@ class FrappeAuthController extends AuthController<FrappeSessionStatusInfo> {
     @required String resetToken,
     @required String newPassword,
   }) async {
+    await getFrappe().checkAppInstalled(features: ['updatePasswordWithToken']);
+
     assert(resetToken != null && resetToken.isNotEmpty,
         "Reset Token can't be empty");
 

--- a/lib/src/backend/frappe/interfaces.dart
+++ b/lib/src/backend/frappe/interfaces.dart
@@ -37,12 +37,21 @@ class AppVersion {
   String get title => _title;
 
   void _parseVersionSegment(String versionString) {
-    final segments = versionString?.split('.');
-    if (segments != null && segments.length == 3) {
-      _major = int.parse(segments[0]);
-      _minor = int.parse(segments[1]);
-      _patch = int.parse(segments[2]);
-      return;
+    if (versionString != null && versionString.isNotEmpty) {
+      final regex = RegExp(r'\d+(\.\d+){2,}');
+
+      final version = regex.firstMatch(versionString);
+
+      if (version != null && version.groupCount > 0) {
+        final segments = version.group(0).split('.');
+
+        if (segments != null && segments.length == 3) {
+          _major = int.parse(segments[0]);
+          _minor = int.parse(segments[1]);
+          _patch = int.parse(segments[2]);
+          return;
+        }
+      }
     }
     throw AppVersionFormatError();
   }


### PR DESCRIPTION
- Add check whether `renovation_core` is installed to use the **Change Password** & **Reset Password** methods.
- Use Regex pattern to parse frappe applications to handle versions like `v13.0.0-beta.2`.
- Null coalesce of `isLoggedIn` getter.