### PR TITLE
fix: Update rawResponse on newDoc

### DIFF
--- a/lib/src/model/frappe/frappe.model.controller.dart
+++ b/lib/src/model/frappe/frappe.model.controller.dart
@@ -36,6 +36,10 @@ class FrappeModelController extends ModelController<FrappeDocument> {
     doc.name = getNewName(doc.doctype);
     doc.isLocal = true;
     doc.unsaved = true;
+    doc.rawResponse = <String, dynamic>{
+      if (doc.rawResponse != null) ...doc.rawResponse,
+      ...doc.toJson(),
+    };
     addToLocals(doc);
     return doc;
   }


### PR DESCRIPTION
This should update the `rawResponse` of the doc when creating a new doc.